### PR TITLE
Delete the help embed message after it's timed out

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -55,10 +55,10 @@ module.exports = {
         .catch(error => console.error(error))
 
       await message.channel.send(pageEmbed).then(async msg => {
-        await msg.react("⏮"); await msg.react("◀"); await msg.react("▶"); await msg.react("⏭"); await msg.react("🗑️")
+        await msg.react("⏮"); await msg.react("◀"); await msg.react("▶"); await msg.react("⏭")
 
         const filter = (reaction, user) => {
-          return (reaction.emoji.name === '⏮' || reaction.emoji.name === '◀' || reaction.emoji.name === '▶' || reaction.emoji.name === '⏭' || reaction.emoji.name === "🗑️") && user.id === message.author.id
+          return (reaction.emoji.name === '⏮' || reaction.emoji.name === '◀' || reaction.emoji.name === '▶' || reaction.emoji.name === '⏭') && user.id === message.author.id
         }
 
         const collector = msg.createReactionCollector(filter, { time: 60000 }) //1 minute
@@ -66,7 +66,6 @@ module.exports = {
         collector.on('collect', async (reaction, user) => {
           if (reaction.emoji.name === "⏮") page = 0 //First
           if (reaction.emoji.name === "⏭") page = pages.length - 1 //Last
-          if (reaction.emoji.name === "🗑️") await msg.delete() // Delete the embed
           if (reaction.emoji.name === "◀") { //Previous
             page--
             if (page < 0) page = 0
@@ -83,6 +82,9 @@ module.exports = {
         collector.on('end', async () => {
           msg.edit(strings.timeOut)
           msg.reactions.removeAll()
+          setTimeout(() => {
+            msg.suppressEmbeds()
+          }, 10000);
         })
       })
 

--- a/commands/help.js
+++ b/commands/help.js
@@ -55,10 +55,10 @@ module.exports = {
         .catch(error => console.error(error))
 
       await message.channel.send(pageEmbed).then(async msg => {
-        await msg.react("⏮"); await msg.react("◀"); await msg.react("▶"); await msg.react("⏭")
+        await msg.react("⏮"); await msg.react("◀"); await msg.react("▶"); await msg.react("⏭"); await msg.react("🗑️")
 
         const filter = (reaction, user) => {
-          return (reaction.emoji.name === '⏮' || reaction.emoji.name === '◀' || reaction.emoji.name === '▶' || reaction.emoji.name === '⏭') && user.id === message.author.id
+          return (reaction.emoji.name === '⏮' || reaction.emoji.name === '◀' || reaction.emoji.name === '▶' || reaction.emoji.name === '⏭' || reaction.emoji.name === "🗑️") && user.id === message.author.id
         }
 
         const collector = msg.createReactionCollector(filter, { time: 60000 }) //1 minute
@@ -66,6 +66,7 @@ module.exports = {
         collector.on('collect', async (reaction, user) => {
           if (reaction.emoji.name === "⏮") page = 0 //First
           if (reaction.emoji.name === "⏭") page = pages.length - 1 //Last
+          if (reaction.emoji.name === "🗑️") await msg.delete() // Delete the embed
           if (reaction.emoji.name === "◀") { //Previous
             page--
             if (page < 0) page = 0


### PR DESCRIPTION
**This option allows the user to close the help menu after they're done using it.**
This is because timed out menus clutter the bots channel a lot.

I also suggest to remove the embed after the menu so people who don't delete their embeds don't make the channel unreadable.