### PR TITLE
Revert license year.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Hypixel Translators
+Copyright (c) 2020 Hypixel Translators
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
According to [this](https://softwareengineering.stackexchange.com/questions/210472/is-renewal-of-mit-license-needed-on-github-at-the-beginning-of-each-year#:~:text=It%20is%20not%2C%20strictly%20speaking,your%20software%20in%20that%20year.) post you shouldn't change your MIT license year.