### PR TITLE
Hide url embed in guidelines tag

### DIFF
--- a/src/commands/Info/tag.ts
+++ b/src/commands/Info/tag.ts
@@ -46,7 +46,7 @@ const command: Command = {
 					'The Hypixel Discord server can be found [here](<https://discord.gg/hypixel> "Hypixel Discord server") (useful for proofreaders).'
 				break
 			case "guidelines":
-				response = 'You can find the official guide for the Hypixel project [here](https://hypixel.net/translate/#post-7078208 "Guide to helping translate Hypixel").'
+				response = 'You can find the official guide for the Hypixel project [here](<https://hypixel.net/translate/#post-7078208> "Guide to helping translate Hypixel").'
 				break
 			case "proofreader":
 				response =


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**
Adds forced URL embed hiding for Hypixel project guidelines link

Please move lines that apply to you out of the comment:
- Code changes were not tested