### PR TITLE
Add support for images in quotes

### DIFF
--- a/src/commands/Utility/quote.ts
+++ b/src/commands/Utility/quote.ts
@@ -220,8 +220,8 @@ async function linkQuote(interaction: Discord.CommandInteraction, collection: Co
 		urlSplit = interaction.options.getString("url", true).split("/");
 	(client.channels.cache.get(urlSplit[5]) as Discord.TextChannel | undefined)?.messages.fetch(urlSplit[6])
 		.then(async msg => {
-			const attachment = msg.attachments.map(a => a.url)[0]
-			const result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url, attachmentURL: attachment } })
+			const firstAttachment = msg.attachments.first()?.url
+			const result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url, attachmentURL: firstAttachment } })
 			if (result.value) {
 				const author = await Promise.all(result.value.author.map(a => client.users.fetch(a))),
 					embed = new Discord.MessageEmbed()
@@ -238,7 +238,7 @@ async function linkQuote(interaction: Discord.CommandInteraction, collection: Co
 							generateTip(),
 							((interaction.member as Discord.GuildMember) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
 						)
-				if (attachment) embed.setImage(attachment)
+				if (firstAttachment) embed.setImage(firstAttachment)
 				await interaction.reply({ embeds: [embed] })
 			} else {
 				const embed = new Discord.MessageEmbed()

--- a/src/commands/Utility/quote.ts
+++ b/src/commands/Utility/quote.ts
@@ -131,7 +131,7 @@ async function findQuote(randomTip: string, interaction: Discord.CommandInteract
 			.setTitle(quote.quote)
 			.setDescription(`      - ${author.join(" and ")}`)
 			.setFooter(randomTip, ((interaction.member as Discord.GuildMember) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
-	if (quote.attachments?.length) embed.setImage(quote.attachments[0])
+	if (quote.attachmentURL) embed.setImage(quote.attachmentURL)
 	if (quote.url) embed.addField(getString("msgUrl"), quote.url)
 	return await interaction.reply({ embeds: [embed] })
 }

--- a/src/commands/Utility/quote.ts
+++ b/src/commands/Utility/quote.ts
@@ -220,8 +220,8 @@ async function linkQuote(interaction: Discord.CommandInteraction, collection: Co
 		urlSplit = interaction.options.getString("url", true).split("/");
 	(client.channels.cache.get(urlSplit[5]) as Discord.TextChannel | undefined)?.messages.fetch(urlSplit[6])
 		.then(async msg => {
-			const attachments: string[] = msg.attachments.map(a => a.url)
-			const result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url, attachments } })
+			const attachment = msg.attachments.map(a => a.url)[0]
+			const result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url, attachmentURL: attachment } })
 			if (result.value) {
 				const author = await Promise.all(result.value.author.map(a => client.users.fetch(a))),
 					embed = new Discord.MessageEmbed()
@@ -238,7 +238,7 @@ async function linkQuote(interaction: Discord.CommandInteraction, collection: Co
 							generateTip(),
 							((interaction.member as Discord.GuildMember) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
 						)
-				if (attachments.length) embed.setImage(attachments[0])
+				if (attachment) embed.setImage(attachment)
 				await interaction.reply({ embeds: [embed] })
 			} else {
 				const embed = new Discord.MessageEmbed()

--- a/src/commands/Utility/quote.ts
+++ b/src/commands/Utility/quote.ts
@@ -147,11 +147,10 @@ async function addQuote(interaction: Discord.CommandInteraction, collection: Col
 	const quoteId = (await collection.estimatedDocumentCount()) + 1,
 		quote = interaction.options.getString("quote", true),
 		author = interaction.options.getUser("author", true),
-		url = interaction.options.getString("url", false)
+		url = interaction.options.getString("url", false),
+		urlSplit = url?.split("/")
 
 	let pictureUrl = interaction.options.getString("pictureUrl", false)
-
-	const urlSplit = url?.split("/")
 
 	if (urlSplit) {
 		if (urlSplit.length === 7) {

--- a/src/commands/Utility/quote.ts
+++ b/src/commands/Utility/quote.ts
@@ -155,7 +155,7 @@ async function addQuote(interaction: Discord.CommandInteraction, collection: Col
 
 
 	if (urlSplit) {
-		if (urlSplit.length > 6) {
+		if (urlSplit.length === 7) {
 			const message = await (client.channels.cache.get(urlSplit[5]) as Discord.TextChannel | undefined)?.messages.fetch(urlSplit[6])
 			if (message) {
 				if (message.attachments.size > 0) pictureUrl = message.attachments.first()?.url
@@ -167,6 +167,13 @@ async function addQuote(interaction: Discord.CommandInteraction, collection: Col
 					.setFooter(generateTip(), ((interaction.member as Discord.GuildMember) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
 				return await interaction.reply({ embeds: [embed], ephemeral: true })
 			}
+		} else {
+			const embed = new Discord.MessageEmbed()
+				.setColor(errorColor as Discord.HexColorString)
+				.setAuthor("Quote")
+				.setTitle("Message URL is invalid!")
+				.setFooter(generateTip(), ((interaction.member as Discord.GuildMember) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+			return await interaction.reply({ embeds: [embed], ephemeral: true })
 		}
 	}
 

--- a/src/commands/Utility/quote.ts
+++ b/src/commands/Utility/quote.ts
@@ -131,6 +131,7 @@ async function findQuote(randomTip: string, interaction: Discord.CommandInteract
 			.setTitle(quote.quote)
 			.setDescription(`      - ${author.join(" and ")}`)
 			.setFooter(randomTip, ((interaction.member as Discord.GuildMember) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+	if (quote.attachments?.length) embed.setImage(quote.attachments[0])
 	if (quote.url) embed.addField(getString("msgUrl"), quote.url)
 	return await interaction.reply({ embeds: [embed] })
 }
@@ -219,7 +220,8 @@ async function linkQuote(interaction: Discord.CommandInteraction, collection: Co
 		urlSplit = interaction.options.getString("url", true).split("/");
 	(client.channels.cache.get(urlSplit[5]) as Discord.TextChannel | undefined)?.messages.fetch(urlSplit[6])
 		.then(async msg => {
-			const result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url } })
+			const attachments: string[] = msg.attachments.map(a => a.url)
+			const result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url, attachments } })
 			if (result.value) {
 				const author = await Promise.all(result.value.author.map(a => client.users.fetch(a))),
 					embed = new Discord.MessageEmbed()
@@ -236,6 +238,7 @@ async function linkQuote(interaction: Discord.CommandInteraction, collection: Co
 							generateTip(),
 							((interaction.member as Discord.GuildMember) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
 						)
+				if (attachments.length) embed.setImage(attachments[0])
 				await interaction.reply({ embeds: [embed] })
 			} else {
 				const embed = new Discord.MessageEmbed()

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -247,7 +247,7 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
-	attachmentURL?: string
+	attachmentURL?: string | undefined
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -247,6 +247,7 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
+	attachmentURL?: string | undefined
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -247,7 +247,7 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
-	attachmentURL?: string | undefined
+	imageURL?: string
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -247,6 +247,7 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
+	attachments?: string[]
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -247,7 +247,7 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
-	attachmentURL?: string | undefined
+	attachmentURL?: string
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -247,7 +247,6 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
-	attachmentURL?: string | undefined
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -247,7 +247,7 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
-	attachments?: string[]
+	attachmentURL?: string
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {

--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -100,9 +100,9 @@ client.on("messageReactionAdd", async (reaction, user) => {
 			urlQuote = await collection.findOne({ url: reaction.message.url })
 		if (!urlQuote) {
 			const id = await collection.estimatedDocumentCount() + 1,
-				attachments: string[] = reaction.message.attachments.map(a => a.url)
+				firstAttachment = reaction.message.attachments.map(a => a.url)[0]
 
-			await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url, attachments })
+			await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url, attachmentURL: firstAttachment })
 			const embed = new Discord.MessageEmbed()
 				.setColor(successColor as Discord.HexColorString)
 				.setAuthor("Starboard")
@@ -113,7 +113,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
 					{ name: "Quote number", value: `${id}` },
 					{ name: "URL", value: reaction.message.url }
 				])
-			if (attachments.length) embed.setImage(attachments[0])
+				.setImage(firstAttachment)
 			await reaction.message.channel.send({ embeds: [embed] })
 		}
 	} else if (reaction.emoji.name === "vote_yes") {

--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -99,9 +99,10 @@ client.on("messageReactionAdd", async (reaction, user) => {
 		const collection = db.collection<Quote>("quotes"),
 			urlQuote = await collection.findOne({ url: reaction.message.url })
 		if (!urlQuote) {
-			const id = await collection.estimatedDocumentCount() + 1
+			const id = await collection.estimatedDocumentCount() + 1,
+				attachments: string[] = reaction.message.attachments.map(a => a.url)
 
-			await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url })
+			await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url, attachments })
 			const embed = new Discord.MessageEmbed()
 				.setColor(successColor as Discord.HexColorString)
 				.setAuthor("Starboard")
@@ -112,6 +113,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
 					{ name: "Quote number", value: `${id}` },
 					{ name: "URL", value: reaction.message.url }
 				])
+			if (attachments.length) embed.setImage(attachments[0])
 			await reaction.message.channel.send({ embeds: [embed] })
 		}
 	} else if (reaction.emoji.name === "vote_yes") {

--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -102,7 +102,8 @@ client.on("messageReactionAdd", async (reaction, user) => {
 			const id = await collection.estimatedDocumentCount() + 1,
 				firstAttachment = reaction.message.attachments.first()?.url
 
-			await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url, imageURL: firstAttachment })
+			if (firstAttachment) await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url, imageURL: firstAttachment })
+			else await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url })
 			const embed = new Discord.MessageEmbed()
 				.setColor(successColor as Discord.HexColorString)
 				.setAuthor("Starboard")

--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -100,7 +100,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
 			urlQuote = await collection.findOne({ url: reaction.message.url })
 		if (!urlQuote) {
 			const id = await collection.estimatedDocumentCount() + 1,
-				firstAttachment = reaction.message.attachments.map(a => a.url)[0]
+				firstAttachment = reaction.message.attachments.first()?.url
 
 			await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url, attachmentURL: firstAttachment })
 			const embed = new Discord.MessageEmbed()

--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -113,7 +113,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
 					{ name: "Quote number", value: `${id}` },
 					{ name: "URL", value: reaction.message.url }
 				])
-				.setImage(firstAttachment)
+			if (firstAttachment) embed.setImage(firstAttachment)
 			await reaction.message.channel.send({ embeds: [embed] })
 		}
 	} else if (reaction.emoji.name === "vote_yes") {

--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -102,7 +102,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
 			const id = await collection.estimatedDocumentCount() + 1,
 				firstAttachment = reaction.message.attachments.first()?.url
 
-			await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url, attachmentURL: firstAttachment })
+			await collection.insertOne({ id: id, quote: reaction.message.content, author: [reaction.message.author.id], url: reaction.message.url, imageURL: firstAttachment })
 			const embed = new Discord.MessageEmbed()
 				.setColor(successColor as Discord.HexColorString)
 				.setAuthor("Starboard")


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**
This PR adds support for images in quotes. Due to embed limitations, only the first attachment is displayed, but I'm open to any other solutions to this problem.

**In this PR:**
- Code changes were not tested
- Core interfaces of the bot were edited (interfaces used in db.collection types e.g. DbUser, LangDbEntry, PunishmentLog and others)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against on a separate test bot
- Environment variables were added/removed
- Strings were edited (text changed while the key stayed the same)
- Strings were added/removed (new/deleted string keys)
- An open issue was fixed/addressed: #
-->