### PR TITLE
Add support for syntax highlighting in GraphQL queries.

### DIFF
--- a/src/commands/Utility/hypixelstats.ts
+++ b/src/commands/Utility/hypixelstats.ts
@@ -3,7 +3,7 @@ import axios from "axios"
 import { ids } from "../../config.json"
 import { db, DbUser } from "../../lib/dbclient"
 import { Command, client, GetStringFunction } from "../../index"
-import { fetchSettings, generateTip, getMCProfile, getUUID, GraphQLQuery, updateRoles } from "../../lib/util"
+import { fetchSettings, generateTip, getMCProfile, getUUID, gql, GraphQLQuery, updateRoles } from "../../lib/util"
 
 //Credits to marzeq for initial implementation
 const command: Command = {
@@ -44,7 +44,7 @@ const command: Command = {
 		const graphqlQuery = await axios
 			.get<GraphQLQuery>("https://api.slothpixel.me/api/graphql", {
 				...fetchSettings,
-				data: { query: query.replaceAll("\t", "").replaceAll("\n", " "), variables: { uuid }, operationName: "HypixelStats" }
+				data: { query: query, variables: { uuid }, operationName: "HypixelStats" }
 			})
 			.then(res => res.data)
 			.catch(e => {
@@ -328,7 +328,7 @@ function parseColorCode(color: string): Discord.HexColorString {
 
 export default command
 
-export const query = `
+export const query = gql`
 				query HypixelStats($uuid: String!) {
 					players {
 						player(player_name: $uuid) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -143,12 +143,12 @@ export async function updateRoles(member: Discord.GuildMember, json?: GraphQLQue
 }
 
 // support for syntax highlighting inside graphql strings (with the right extensions) (also makes it a one liner)
-export function gql(templateStringWoSubs: TemplateStringsArray, ...substitutions: any[]) {
-	let returnString = ""
-	for (let i = 0; i < templateStringWoSubs.length; i++) {
-		returnString += templateStringWoSubs[i] + (substitutions[i] ?? "")
+export function gql(cleanText: TemplateStringsArray, ...substitutions: any[]) {
+	let returnQuery = ""
+	for (let i = 0; i < cleanText.length; i++) {
+		returnQuery += cleanText[i] + (substitutions[i] ?? "")
 	}
-	return returnString.replaceAll("\t", "").replaceAll("\n", " ")
+	return returnQuery.replaceAll("\t", "").replaceAll("\n", " ")
 }
 
 export interface GraphQLQuery {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -252,7 +252,6 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
-	attachmentURL?: string | undefined
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -144,7 +144,7 @@ export async function updateRoles(member: Discord.GuildMember, json?: GraphQLQue
 
 // support for syntax highlighting inside graphql strings (with the right extensions) (also makes it a one liner)
 export function gql(templateString: TemplateStringsArray, ...substitutions: any[]) {
-	return templateString.reduce((acc, cur, i) => acc + (substitutions[i - 1] || "") + cur)
+	return templateString.reduce((acc, cur, i) => acc + (substitutions[i - 1] || "") + cur).replaceAll("\t", "").replaceAll("\n", " ")
 }
 
 export interface GraphQLQuery {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -144,7 +144,11 @@ export async function updateRoles(member: Discord.GuildMember, json?: GraphQLQue
 
 // support for syntax highlighting inside graphql strings (with the right extensions) (also makes it a one liner)
 export function gql(templateString: TemplateStringsArray, ...substitutions: any[]) {
-	return templateString.reduce((acc, cur, i) => acc + (substitutions[i - 1] || "") + cur).replaceAll("\t", "").replaceAll("\n", " ")
+	let returnString = ""
+	for (let i = 0; i < templateString.length; i++) {
+		returnString += templateString[i] + (substitutions[i] ?? "")
+	}
+	return returnString.replaceAll("\t", "").replaceAll("\n", " ")
 }
 
 export interface GraphQLQuery {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -143,10 +143,10 @@ export async function updateRoles(member: Discord.GuildMember, json?: GraphQLQue
 }
 
 // support for syntax highlighting inside graphql strings (with the right extensions) (also makes it a one liner)
-export function gql(templateString: TemplateStringsArray, ...substitutions: any[]) {
+export function gql(templateStringWoSubs: TemplateStringsArray, ...substitutions: any[]) {
 	let returnString = ""
-	for (let i = 0; i < templateString.length; i++) {
-		returnString += templateString[i] + (substitutions[i] ?? "")
+	for (let i = 0; i < templateStringWoSubs.length; i++) {
+		returnString += templateStringWoSubs[i] + (substitutions[i] ?? "")
 	}
 	return returnString.replaceAll("\t", "").replaceAll("\n", " ")
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -142,6 +142,11 @@ export async function updateRoles(member: Discord.GuildMember, json?: GraphQLQue
 	return role
 }
 
+// support for syntax highlighting inside graphql strings (with the right extensions) (also makes it a one liner)
+export function gql(templateString: TemplateStringsArray, ...substitutions: any[]) {
+	return templateString.reduce((acc, cur, i) => acc + (substitutions[i - 1] || "") + cur)
+}
+
 export interface GraphQLQuery {
 	errors?: {
 		message: string
@@ -247,6 +252,7 @@ export interface Quote {
 	id: number
 	quote: string
 	url?: string
+	attachmentURL?: string | undefined
 }
 
 export async function restart(interaction?: Discord.CommandInteraction) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**
This PR adds an option for syntax highlighting in GraphQL query strings, with the use of the new `gql` function (tag) in `util.ts`. For this to work you need the [GraphQL](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) extension in VsCode. This function (tag) also handles deleting all `\t` chars and replacing all newlines with spaces (this was previously done manually before sending the request).

**In this PR:**
- Code changes were not tested

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against on a separate test bot
- Environment variables were added/removed
- Core interfaces of the bot were edited (interfaces used in db.collection types e.g. DbUser, LangDbEntry, PunishmentLog and others)
- Strings were edited (text changed while the key stayed the same)
- Strings were added/removed (new/deleted string keys)
- An open issue was fixed/addressed: #
-->