### PR TITLE
refactor: prefer using the constructor instead of functions on builders

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,6 +4,6 @@
 	"useTabs": true,
 	"semi": false,
 	"proseWrap": "never",
-	"printWidth": 140,
+	"printWidth": 150,
 	"arrowParens": "avoid"
 }

--- a/src/commands/Admin/bulksend.ts
+++ b/src/commands/Admin/bulksend.ts
@@ -31,18 +31,19 @@ const command: Command = {
 	}],
 	async execute(interaction) {
 		if (!interaction.inCachedGuild()) return
-		const channel = interaction.options.getChannel("channel", true) as TextChannel
+		const channel = interaction.options.getChannel("channel", true) as TextChannel,
+			amount = interaction.options.getInteger("amount", true)
 
 		if (!channel) throw "Couldn't resolve that channel!"
-		let amount = interaction.options.getInteger("amount", true)
 		await interaction.deferReply()
 		for (let i = amount; i > 0; i--) await channel.send("Language statistics will be here shortly!")
-		const embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor("Bulk Send")
-			.setTitle(`Success! Message${amount === 1 ? "" : "s"} sent!`)
-			.setDescription(`${channel}`)
-			.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: "Bulk Send" },
+			title: `Success! Message${amount === 1 ? "" : "s"} sent!`,
+			description: `${channel}`,
+			footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		await interaction.editReply({ embeds: [embed] })
 		if (interaction.options.getBoolean("update", false)) {
 			const project = await db.collection<CrowdinProject>("crowdin").findOne({ shortName: channel.name.split("-")[0] })

--- a/src/commands/Admin/channel.ts
+++ b/src/commands/Admin/channel.ts
@@ -64,8 +64,7 @@ const command: Command = {
 				color: colors.success,
 				author: { name: "Channel updater" },
 				title: "Updated all channels!",
-				description: `Check them out at <#${ids.channels.serverInfo}>, ${interaction.guild!.rulesChannel} and <#${ids.channels.verify
-					}>!`,
+				description: `Check them out at <#${ids.channels.serverInfo}>, ${interaction.guild!.rulesChannel} and <#${ids.channels.verify}>!`,
 				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
 			})
 			await interaction.editReply({ embeds: [successEmbed] })

--- a/src/commands/Admin/channel.ts
+++ b/src/commands/Admin/channel.ts
@@ -15,7 +15,7 @@ const command: Command = {
 		description: "The channel to update",
 		required: false,
 		choices: [
-			{ name: "The #rules channel", value: "rules", },
+			{ name: "The #rules channel", value: "rules" },
 			{ name: "The #server-info channel", value: "info" },
 			{ name: "The #verify channel", value: "verify" }
 		]
@@ -28,123 +28,204 @@ const command: Command = {
 		await interaction.deferReply()
 		if (channelInput === "info") {
 			await info(interaction)
-			const successEmbed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor("Channel updater")
-				.setTitle("Updated the information channel!")
-				.setDescription(`Check it out at <#${ids.channels.serverInfo}>!`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const successEmbed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Channel updater" },
+				title: "Updated the information channel!",
+				description: `Check it out at <#${ids.channels.serverInfo}>!`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			await interaction.editReply({ embeds: [successEmbed] })
 		} else if (channelInput === "rules") {
 			await rules(interaction)
-			const successEmbed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor("Channel updater")
-				.setTitle("Updated the rules channel!")
-				.setDescription(`Check it out at ${interaction.guild.rulesChannel}!`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const successEmbed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Channel updater" },
+				title: "Updated the rules channel!",
+				description: `Check it out at <#${interaction.guild.rulesChannel}>!`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			await interaction.editReply({ embeds: [successEmbed] })
 		} else if (channelInput === "verify") {
 			await verify(interaction)
-			const successEmbed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor("Channel updater")
-				.setTitle("Updated the verification channel!")
-				.setDescription(`Check it out at <#${ids.channels.verify}>!`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const successEmbed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Channel updater" },
+				title: "Updated the verification channel!",
+				description: `Check it out at <#${ids.channels.verify}>!`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			await interaction.editReply({ embeds: [successEmbed] })
 		} else if (!channelInput) {
 			await info(interaction)
 			await verify(interaction)
 			await rules(interaction)
-			const successEmbed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor("Channel updater")
-				.setTitle("All channels have been updated!")
-				.setDescription(`Check them out at <#${ids.channels.serverInfo}>, ${interaction.guild!.rulesChannel} and <#${ids.channels.verify}>!`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const successEmbed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Channel updater" },
+				title: "Updated all channels!",
+				description: `Check them out at <#${ids.channels.serverInfo}>, ${interaction.guild!.rulesChannel} and <#${ids.channels.verify
+					}>!`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			await interaction.editReply({ embeds: [successEmbed] })
 		}
 	}
 }
 
-async function info(interaction: CommandInteraction) {
+async function info(interaction: CommandInteraction<"cached">) {
 	const serverInfo = interaction.client.channels.cache.get(ids.channels.serverInfo) as TextChannel,
 		channelsMessage = await serverInfo.messages.fetch("800415708851732491"),
-		channelsEmbed = new MessageEmbed()
-			.setColor("#0022ff")
-			.setTitle("Channels")
-			.setDescription("Each channel has important information pinned in it. We highly recommend checking it out.")
-			.addFields(
-				{ name: "**Important ❕**", value: `<#${ids.channels.announcements}> - Important messages from the server's admins.\n<#787050912005881876> - The channel where giveaways are hosted.\n<#${ids.channels.botUpdates}> - Here, updates to ${interaction.client.user} will be posted every now and then.\n<#646096405252800512> - In this channel we will post polls that you will be able to vote on in order to influence certain changes on the server.\n<#758314105328762912> - Updates from our bot's [GitHub repository](https://github.com/Hypixel-Translators/hypixel-translators-bot).\n<#${ids.channels.twitter}> - The feed of our [@HTranslators](https://twitter.com/HTranslators) Twitter page.\n${interaction.guild!.rulesChannel} - All rules are listed here. Follow them, or there'll be consequences.\n<#${ids.channels.serverInfo}> - This channel has an overview of the server to help you understand how it works.\n<#699275092026458122> - A full guide on Crowdin available to all translators! Here you'll find basic and advanced tools to help you translate.\n<#${ids.channels.joinLeave}> - Displays members who join and leave the server.` },
-				{ name: "**Main Channels 💬**", value: `<#621298919535804426> - You can use this channel to talk about anything you want really.\n<#619662798133133312> - A text channel where you can post your favorite memes.\n<#712046319375482910> - Post pics of your or someone else's cute pets here.\n<#644620638878695424> - A special channel for special people that have boosted our server. Thank you!\n<#550951034332381184> - A text channel where you can suggest things you would like to see on this Discord server.\n<#${ids.channels.bots}> -  A channel for you to use bot commands in.\n<#713084081579098152> - A text channel you can use when you can't speak in a voice chat.` },
-				{ name: "**Translation Channels 🔠**", value: "We offer channels for each one of the currently supported projects: **Hypixel**, **SkyblockAddons**, **Quickplay** and our **Bot**.\nEach category has 3 text channels: one for translators, one for proofreaders and one with the project's language status that gets updated every 20 minutes. They also have 2 voice channels: one for translators and one for proofreaders. If you have any questions related to your project, they should be sent here!" },
-				{ name: "**Language-specific channels 🌐**", value: "We offer channels where translators and proofreaders (of the Hypixel project) for specific languages can interact with one another! You can speak in English there, but we encourage you to speak the language you're translating. Please keep in mind these channels are not actively moderated. In case you need to report something that occured in these channels, please contact an administrator." })
+		channelsEmbed = new MessageEmbed({
+			color: "#0022FF",
+			title: "Channels",
+			description: "Each channel has important information pinned in it. We highly recommend checking it out.",
+			fields: [
+				{
+					name: "**Important ❕**",
+					value: `<#${ids.channels.announcements}> - Important messages from the server's admins.\n<#787050912005881876> - The channel where giveaways are hosted.\n<#${ids.channels.botUpdates}> - Here, updates to ${interaction.client.user} will be posted every now and then.\n<#646096405252800512> - In this channel we will post polls that you will be able to vote on in order to influence certain changes on the server.\n<#758314105328762912> - Updates from our bot's [GitHub repository](https://github.com/Hypixel-Translators/hypixel-translators-bot).\n<#${ids.channels.twitter}> - The feed of our [@HTranslators](https://twitter.com/HTranslators) Twitter page.\n${interaction.guild.rulesChannel} - All rules are listed here. Follow them, or there'll be consequences.\n<#${ids.channels.serverInfo}> - This channel has an overview of the server to help you understand how it works.\n<#699275092026458122> - A full guide on Crowdin available to all translators! Here you'll find basic and advanced tools to help you translate.\n<#${ids.channels.joinLeave}> - Displays members who join and leave the server.`
+				},
+				{
+					name: "**Main Channels 💬**",
+					value: `<#621298919535804426> - You can use this channel to talk about anything you want really.\n<#619662798133133312> - A text channel where you can post your favorite memes.\n<#712046319375482910> - Post pics of your or someone else's cute pets here.\n<#644620638878695424> - A special channel for special people that have boosted our server. Thank you!\n<#550951034332381184> - A text channel where you can suggest things you would like to see on this Discord server.\n<#${ids.channels.bots}> -  A channel for you to use bot commands in.\n<#713084081579098152> - A text channel you can use when you can't speak in a voice chat.`
+				},
+				{
+					name: "**Translation Channels 🔠**",
+					value: "We offer channels for each one of the currently supported projects: **Hypixel**, **SkyblockAddons**, **Quickplay** and our **Bot**.\nEach category has 3 text channels: one for translators, one for proofreaders and one with the project's language status that gets updated every 20 minutes. They also have 2 voice channels: one for translators and one for proofreaders. If you have any questions related to your project, they should be sent here!"
+				},
+				{
+					name: "**Language-specific channels 🌐**",
+					value: "We offer channels where translators and proofreaders (of the Hypixel project) for specific languages can interact with one another! You can speak in English there, but we encourage you to speak the language you're translating. Please keep in mind these channels are not actively moderated. In case you need to report something that occured in these channels, please contact an administrator."
+				}
+			]
+		})
 	await channelsMessage.edit({ content: null, embeds: [channelsEmbed] })
 
-	const botsMessage = await serverInfo.messages.fetch("800415710508744744"),
-		botsEmbed = new MessageEmbed()
-			.setColor("#0055ff")
-			.setTitle("Bots")
-			.setDescription(`Information about all bots on this server can be found here. The character inside the [] in their nickname indicates their prefix. Use [prefix]help in <#${ids.channels.bots}> to know more about them.`)
-			.addFields(
-				{ name: "**Bots**", value: `${interaction.client.user} - Our personalised bot! It is currently maintained by <@!240875059953139714> and has a bunch of useful features.\n<@!155149108183695360> - This is Dyno. He is used for moderation purposes and nothing else, so don't mind him.\n<@!472911936951156740> - VoiceMaster allows you to create custom voice channels by joining the <#880889993629941830> channel and you can use <#${ids.channels.bots}> to customise them.\n<@!819778342818414632> - Activities is a bot that, despite appearing as offline, lets you play games and do other fun things in voice chats! Try running the \`/activity\` command to try them out.` },
-				{ name: "**How to verify link your Crowdin profile with our bot**", value: "Our server uses a custom verification system to always keep your roles synced with your Crowdin profile. In order to ensure that these are up to date, there are a few things you can do:\n - **Check if your profile is stored in our database.** This can be done by executing the `/profile` command (can be used anywhere)\n - **Update your roles manually.** If your roles have recently changed and you just can't wait for the bot to update them automatically, you can execute `/verify` and include your Crowdin profile (or not, if it's already stored) in the url parameter (press tab after typing the command to see all parameters)\nIf your profile is already stored, your roles will be automatically updated every day around 3am UTC, so you should not need to worry about this. If you notice a discrepancy in your roles, please contact the main developer of the bot." }
-			)
-	await botsMessage.edit({ content: null, embeds: [botsEmbed] })
+	const botsEmbed = new MessageEmbed({
+		color: "#0055FF",
+		title: "Bots",
+		description: `Information about all bots on this server can be found here. The character inside the [] in their nickname indicates their prefix. Use [prefix]help in <#${ids.channels.bots}> to know more about them.`,
+		fields: [
+			{
+				name: "**Bots**",
+				value: `${interaction.client.user} - Our personalised bot! It is currently maintained by <@!240875059953139714> and has a bunch of useful features.\n<@!155149108183695360> - This is Dyno. He is used for moderation purposes and nothing else, so don't mind him.\n<@!472911936951156740> - VoiceMaster allows you to create custom voice channels by joining the <#880889993629941830> channel and you can use <#${ids.channels.bots}> to customise them.\n<@!819778342818414632> - Activities is a bot that, despite appearing as offline, lets you play games and do other fun things in voice chats! Try running the \`/activity\` command to try them out.`
+			},
+			{
+				name: "**How to verify link your Crowdin profile with our bot**",
+				value: "Our server uses a custom verification system to always keep your roles synced with your Crowdin profile. In order to ensure that these are up to date, there are a few things you can do:\n - **Check if your profile is stored in our database.** This can be done by executing the `/profile` command (can be used anywhere)\n - **Update your roles manually.** If your roles have recently changed and you just can't wait for the bot to update them automatically, you can execute `/verify` and include your Crowdin profile (or not, if it's already stored) in the url parameter (press tab after typing the command to see all parameters)\nIf your profile is already stored, your roles will be automatically updated every day around 3am UTC, so you should not need to worry about this. If you notice a discrepancy in your roles, please contact the main developer of the bot."
+			}
+		]
+	})
+	await serverInfo.messages.edit("800415710508744744", { content: null, embeds: [botsEmbed] })
 
-	const rolesMessage = await serverInfo.messages.fetch("800415711864029204"),
-		rolesEmbed = new MessageEmbed()
-			.setColor("#0077ff")
-			.setTitle("Roles")
-			.setDescription("Every role has a meaning behind it. Find out what they all are below!")
-			.addFields(
-				{ name: "**Discord staff**", value: "<@&549885900151193610> - The Discord Owner, <@!241926666400563203>, and Co-Owner, <@!240875059953139714>!\n<@&764442984119795732> - The Discord Administrator, <@!435546264432803840>!\n<@&621071221462663169> - Our beloved Discord Moderators who keep the chats clean.\n<@&621071248079716355> - Our amazing Discord Helpers, they're basically minimods." },
-				{ name: "**Official Hypixel staff members**", value: "They do not moderate the Discord but they can be helpful when it comes to asking things regarding translation or the server (refer to rule 5).\n<@&624880339722174464> - Official Hypixel Administrators.\n<@&822787676482699297> - Official Hypixel Game Masters." },
-				{ name: "**Translators**", value: `Each of the following roles applies to all 4 projects we support: **Hypixel**, **SkyblockAddons**, **Quickplay** and our **Bot**.\n**Managers** - The managers of each project are the ones responsible for new strings, proofreader promotions, amongst other things. Please avoid tagging people with these roles (refer to rule 5).\n**Proofreaders** - The proofreaders of each language are the ones responsible for reviewing and approving strings. If you notice any mistakes, these are the people you should message.\n**Translators** - A translator's job is to suggest and vote on translations, which helps the proofreaders' job a lot.\n\nAdditionally, **Hypixel** translators get access to **Veteran Roles**, roles showing how long you've been on the project for, and **Language Roles**, which give you access to your language's private channels (refer to the [language-specific channels section](${channelsMessage.url}))` },
-				{ name: "**Miscellaneous**", value: `<@&549894155174674432> - A role given to all bots in the Discord.\n<@&732586582787358781> - A role given to the current developer(s) of our bot.\n<@&618502156638617640> - A role given to people who have helped create art for this server.\n<@&766339653615484930> - A role given to the person who won the Trick'cord Treat contest in October 2020, <@!435546264432803840>\n<@&719263346909773864> - A role given to all of the people who've hosted giveaways in <#787050912005881876>!\n<@&557090185670557716> - A role given to all users that joined in the first 6 months of this server (August 28, 2019).` },
-				{ name: "**Self-roles**", value: `You can click on the buttons below to receive their corresponding roles. Here's what they do:\n<@&646098170794868757> - Click on the "📊 Polls" button to be notified whenever a new poll is posted on <#646096405252800512>.\n<@&732615152246980628> - Click on the "🤖 Bot Updates" button to be notified whenever a new major update to ${interaction.client.user} is posted on <#${ids.channels.botUpdates}>.\n<@&801052623745974272> - Click on the  "🎉 Giveaway Pings" button to be notified of future giveaways in <#787050912005881876>. Note that you must be at least chat level 5 to receive this role (you can check your level by doing /rank in <#${ids.channels.bots}>).\n<@&898319248953311272> - Click on the "<:crowdin:878439498717999196> Crowdin Updates" button to be notified whenever strings are added or removed from a project, or whenever the Hypixel project is built.` }
-			)
-			.setFooter("Need help? Ask your questions in #off-topic")
-	await rolesMessage.edit({ content: null, embeds: [rolesEmbed] })
+	const rolesEmbed = new MessageEmbed({
+		color: "#0077FF",
+		title: "Roles",
+		description: "Every role has a meaning behind it. Find out what they all are below!",
+		fields: [
+			{
+				name: "**Discord staff**",
+				value: "<@&549885900151193610> - The Discord Owner, <@!241926666400563203>, and Co-Owner, <@!240875059953139714>!\n<@&764442984119795732> - The Discord Administrator, <@!435546264432803840>!\n<@&621071221462663169> - Our beloved Discord Moderators who keep the chats clean.\n<@&621071248079716355> - Our amazing Discord Helpers, they're basically minimods."
+			},
+			{
+				name: "**Official Hypixel staff members**",
+				value: "They do not moderate the Discord but they can be helpful when it comes to asking things regarding translation or the server (refer to rule 5).\n<@&624880339722174464> - Official Hypixel Administrators.\n<@&822787676482699297> - Official Hypixel Game Masters."
+			},
+			{
+				name: "**Translators**",
+				value: `Each of the following roles applies to all 4 projects we support: **Hypixel**, **SkyblockAddons**, **Quickplay** and our **Bot**.\n**Managers** - The managers of each project are the ones responsible for new strings, proofreader promotions, amongst other things. Please avoid tagging people with these roles (refer to rule 5).\n**Proofreaders** - The proofreaders of each language are the ones responsible for reviewing and approving strings. If you notice any mistakes, these are the people you should message.\n**Translators** - A translator's job is to suggest and vote on translations, which helps the proofreaders' job a lot.\n\nAdditionally, **Hypixel** translators get access to **Veteran Roles**, roles showing how long you've been on the project for, and **Language Roles**, which give you access to your language's private channels (refer to the [language-specific channels section](${channelsMessage.url}))`
+			},
+			{
+				name: "**Miscellaneous**",
+				value: `<@&549894155174674432> - A role given to all bots in the Discord.\n<@&732586582787358781> - A role given to the current developer(s) of our bot.\n<@&618502156638617640> - A role given to people who have helped create art for this server.\n<@&766339653615484930> - A role given to the person who won the Trick'cord Treat contest in October 2020, <@!435546264432803840>\n<@&719263346909773864> - A role given to all of the people who've hosted giveaways in <#787050912005881876>!\n<@&557090185670557716> - A role given to all users that joined in the first 6 months of this server (August 28, 2019).`
+			},
+			{
+				name: "**Self-roles**",
+				value: `You can click on the buttons below to receive their corresponding roles. Here's what they do:\n<@&646098170794868757> - Click on the "📊 Polls" button to be notified whenever a new poll is posted on <#646096405252800512>.\n<@&732615152246980628> - Click on the "🤖 Bot Updates" button to be notified whenever a new major update to ${interaction.client.user} is posted on <#${ids.channels.botUpdates}>.\n<@&801052623745974272> - Click on the  "🎉 Giveaway Pings" button to be notified of future giveaways in <#787050912005881876>. Note that you must be at least chat level 5 to receive this role (you can check your level by doing /rank in <#${ids.channels.bots}>).\n<@&898319248953311272> - Click on the "<:crowdin:878439498717999196> Crowdin Updates" button to be notified whenever strings are added or removed from a project, or whenever the Hypixel project is built.`
+			}
+		],
+		footer: { text: "Need help? Ask your questions in #off-topic" }
+	})
+	await serverInfo.messages.edit("800415711864029204", { content: null, embeds: [rolesEmbed] })
 }
 
-async function rules(interaction: CommandInteraction) {
-	const rulesMessage = await interaction.guild!.rulesChannel!.messages.fetch("800412977220026398"),
-		rulesEmbed = new MessageEmbed()
-			.setColor("BLURPLE")
-			.setTitle("Server Rules")
-			.setDescription("Welcome  to the rules channel! In this channel, you will find every rule on this discord server. Please do not break any of the rules listed below or there will be consequences.")
-			.addFields(
-				{ name: "1 - Do not say anything that might be offensive to someone else.", value: "This includes racial slurs and sexist terms, etc." },
-				{ name: "2 - Do not impersonate anyone.", value: "This is currently mentioned specifically when you first join the discord but it also applies to other situations after you've been verified so please refrain from doing it." },
-				{ name: "3 - Do not encourage self-harm or even threaten to kill anybody.", value: "These offenses will result in a permanent ban from the discord and a report to Discord's ToS team." },
-				{ name: "4 - Nicks", value: "Your nickname must not contain zalgo or a prefix for a language you do not translate (e.g. `[PT]` or `[🇵🇹]`). It should also obey the remaining rules." },
-				{ name: "5 - Do not excessively tag Discord and Hypixel Staff members/project managers.", value: "You are allowed to tag staff but please keep it to a minimum and only do so if you need an important question answered. Otherwise, please refrain from doing it. Please do not tag project managers unless they allow you to." },
-				{ name: "6 - Always try to speak in English.", value: "If you make a reference in another language on a public channel, please explain to the people who don't speak that language what it means." },
-				{ name: "7 - Follow all Hypixel rules.", value: "If you are not familiar with those, check them out [here](https://hypixel.net/rules)." },
-				{ name: "8- Follow Discord's ToS and Community Guidelines", value: "This includes not using modified Discord clients, self bots and more. Click [here](https://discord.com/terms) to read the ToS, or [here](https://discord.com/guidelines) to read the Community Guidelines" },
-				{ name: "And most importantly have fun!", value: "If you see something against the rules or something that makes you feel unsafe, please let staff know. We want this server to be a welcoming space for everyone!" }
-			)
-			.setFooter("Have any questions? Ask any staff member, they're here to help!")
-	await rulesMessage.edit({ content: null, embeds: [rulesEmbed] })
+async function rules(interaction: CommandInteraction<"cached">) {
+	const rulesEmbed = new MessageEmbed({
+		color: "BLURPLE",
+		title: "Server Rules",
+		description:
+			"Welcome to the rules channel! In this channel, you will find every rule on this discord server. Please do not break any of the rules listed below or there will be consequences.",
+		fields: [
+			{
+				name: "1 - Do not say anything that might be offensive to someone else.",
+				value: "This includes racial slurs and sexist terms, etc."
+			},
+			{
+				name: "2 - Do not impersonate anyone.",
+				value: "This is currently mentioned specifically when you first join the discord but it also applies to other situations after you've been verified so please refrain from doing it."
+			},
+			{
+				name: "3 - Do not encourage self-harm or even threaten to kill anybody.",
+				value: "These offenses will result in a permanent ban from the discord and a report to Discord's ToS team."
+			},
+			{
+				name: "4 - Nicks",
+				value: "Your nickname must not contain zalgo or a prefix for a language you do not translate (e.g. `[PT]` or `[🇵🇹]`). It should also obey the remaining rules."
+			},
+			{
+				name: "5 - Do not excessively tag Discord and Hypixel Staff members/project managers.",
+				value: "You are allowed to tag staff but please keep it to a minimum and only do so if you need an important question answered. Otherwise, please refrain from doing it. Please do not tag project managers unless they allow you to."
+			},
+			{
+				name: "6 - Always try to speak in English.",
+				value: "If you make a reference in another language on a public channel, please explain to the people who don't speak that language what it means."
+			},
+			{
+				name: "7 - Follow all Hypixel rules.",
+				value: "If you are not familiar with those, check them out [here](https://hypixel.net/rules)."
+			},
+			{
+				name: "8- Follow Discord's ToS and Community Guidelines",
+				value: "This includes not using modified Discord clients, self bots and more. Click [here](https://discord.com/terms) to read the ToS, or [here](https://discord.com/guidelines) to read the Community Guidelines"
+			},
+			{
+				name: "And most importantly have fun!",
+				value: "If you see something against the rules or something that makes you feel unsafe, please let staff know. We want this server to be a welcoming space for everyone!"
+			}
+		],
+		footer: { text: "Have any questions? Ask any staff member, they're here to help!" }
+	})
+	await interaction.guild!.rulesChannel!.messages.edit("800412977220026398", { content: null, embeds: [rulesEmbed] })
 }
 
-async function verify(interaction: CommandInteraction) {
-	const verifyMessage = await (interaction.client.channels.cache.get(ids.channels.verify) as TextChannel).messages.fetch("787366444970541056"),
-		verifyEmbed = new MessageEmbed()
-			.setColor("BLURPLE")
-			.setAuthor("Welcome!")
-			.setThumbnail(interaction.guild!.iconURL({ format: "png", dynamic: true })!)
-			.setTitle("The Hypixel Translators Community")
-			.setDescription(`Hello there and welcome to the __**Unofficial**__ Hypixel Translators Server! In order to verify yourself to have access to other channels, please follow the instructions below. While you wait we also suggest you check out ${interaction.guild!.rulesChannel} to be more familiar with the server rules once you've joined.`)
-			.addFields(
-				{ name: "Translator/Proofreader", value: "If you are a translator or proofreader for either the **Hypixel**, **Quickplay** or **SkyblockAddons** projects, please send us the link to your Crowdin profile (e.g. <https://crowdin.com/profile/ImRodry> **and not** <https://crowdin.com/profile>) on **this channel** so that you can be automatically verified. Keep in mind that in order to be verified, your profile must be **public** and you must include your Discord username and discriminator in your \"About\" section (eg: Rodry#4020). If you don't receive your roles within 1 minute, please contact <@!240875059953139714>." },
-				{ name: "Not a translator", value: "If you're not a translator for either one of the projects mentioned above and just want to join the server for fun, please run `/verify` in order to receive your roles. If this doesn't work, please mention <@!240875059953139714> on this channel saying so." },
-				{ name: "Need help?", value: "Feel free to send a message on this channel, or DM either <@!240875059953139714>, <@!241926666400563203> or <@!435546264432803840> with any questions you might have!" }
-			)
-			.setFooter("Have fun on our server!")
-	await verifyMessage.edit({ content: "**Please read the entire message before sending anything on the channel.**", embeds: [verifyEmbed] })
+async function verify(interaction: CommandInteraction<"cached">) {
+	const verifyEmbed = new MessageEmbed({
+		color: "BLURPLE",
+		author: { name: "Welcome!" },
+		thumbnail: { url: interaction.guild.iconURL({ format: "png", dynamic: true })! },
+		title: `The ${interaction.guild.name}`,
+		description: `Hello there and welcome to the __**Unofficial**__ Hypixel Translators Server! In order to verify yourself to have access to other channels, please follow the instructions below. While you wait we also suggest you check out ${interaction.guild!.rulesChannel
+			} to be more familiar with the server rules once you've joined.`,
+		fields: [
+			{
+				name: "Translator/Proofreader",
+				value: 'If you are a translator or proofreader for either the **Hypixel**, **Quickplay** or **SkyblockAddons** projects, please send us the link to your Crowdin profile (e.g. <https://crowdin.com/profile/ImRodry> **and not** <https://crowdin.com/profile>) on **this channel** so that you can be automatically verified. Keep in mind that in order to be verified, your profile must be **public** and you must include your Discord username and discriminator in your "About" section (eg: Rodry#4020). If you don\'t receive your roles within 1 minute, please contact <@!240875059953139714>.'
+			},
+			{
+				name: "Not a translator",
+				value: "If you're not a translator for either one of the projects mentioned above and just want to join the server for fun, please run `/verify` in order to receive your roles. If this doesn't work, please mention <@!240875059953139714> on this channel saying so."
+			},
+			{
+				name: "Need help?",
+				value: "Feel free to send a message on this channel, or DM either <@!240875059953139714>, <@!241926666400563203> or <@!435546264432803840> with any questions you might have!"
+			}
+		],
+		footer: { text: "Have fun on our server!" }
+	})
+	await (interaction.client.channels.cache.get(ids.channels.verify) as TextChannel).messages.edit("787366444970541056", {
+		content: "**Please read the entire message before sending anything on the channel.**",
+		embeds: [verifyEmbed]
+	})
 }
 
 export default command

--- a/src/commands/Admin/crowdinverify.ts
+++ b/src/commands/Admin/crowdinverify.ts
@@ -21,12 +21,13 @@ const command: Command = {
 
 		await interaction.deferReply()
 		await crowdinVerify(limit)
-		const embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor("Role updater")
-			.setTitle("All verified users had their roles updated!")
-			.setDescription("Check the console for any errors that may have occured in the process")
-			.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: "Role updater" },
+			title: "All verified users had their roles updated!",
+			description: "Check the console for any errors that may have occured in the process",
+			footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		await interaction.editReply({ embeds: [embed] })
 			.catch(async () => {
 				await interaction.channel!.send({ content: "The interaction expired, so here's the embed so you don't feel sad", embeds: [embed] })

--- a/src/commands/Admin/eval.ts
+++ b/src/commands/Admin/eval.ts
@@ -54,11 +54,11 @@ const command: Command = {
 		try {
 			evaled = await eval(compiledCode)
 			const inspected = inspect(evaled, { depth: 1, getters: true }),
-				embed = new discord.MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor("Evaluation")
-					.setTitle("The code was executed successfully! Here's the output")
-					.addFields(
+				embed = new discord.MessageEmbed({
+					color: colors.success,
+					author: { name: "Evaluation" },
+					title: "The code was executed successfully! Here's the output",
+					fields: [
 						{ name: "Input", value: discord.Formatters.codeBlock("ts", codeToRun.substring(0, 1015)) },
 						{ name: "Compiled code", value: discord.Formatters.codeBlock("js", compiledCode.replaceAll(";", "").substring(0, 1015)) },
 						{ name: "Output", value: discord.Formatters.codeBlock("js", inspected.substring(0, 1015)) },
@@ -73,16 +73,17 @@ const command: Command = {
 						},
 						{ name: "Output length", value: `${inspected.length}`, inline: true },
 						{ name: "Time taken", value: `${(Date.now() - interaction.createdTimestamp).toLocaleString()}ms`, inline: true }
-					)
-					.setFooter(generateTip(), me.displayAvatarURL({ format: "png", dynamic: true }))
+					],
+					footer: { text: generateTip(), iconURL: me.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 			await interaction.editReply({ embeds: [embed] })
 			console.log(evaled)
 		} catch (error) {
-			const embed = new discord.MessageEmbed()
-				.setColor(colors.error)
-				.setAuthor("Evaluation")
-				.setTitle("An error occured while executing that code. Here's the error stack")
-				.addFields(
+			const embed = new discord.MessageEmbed({
+				color: colors.error,
+				author: { name: "Evaluation" },
+				title: "An error occured while executing that code. Here's the error stack",
+				fields: [
 					{ name: "Input", value: discord.Formatters.codeBlock("ts", codeToRun.substring(0, 1015)) },
 					{ name: "Compiled code", value: discord.Formatters.codeBlock("js", compiledCode.replaceAll(";", "").substring(0, 1015)) },
 					{ name: "Error", value: discord.Formatters.codeBlock(error.stack.substring(0, 1017)) },
@@ -90,8 +91,9 @@ const command: Command = {
 					{ name: "Error Type", value: error.name, inline: true },
 					{ name: "Error length", value: `${error.stack.length}`, inline: true },
 					{ name: "Time taken", value: `${(Date.now() - interaction.createdTimestamp).toLocaleString()}ms`, inline: true }
-				)
-				.setFooter(generateTip(), me.displayAvatarURL({ format: "png", dynamic: true }))
+				],
+				footer: { text: generateTip(), iconURL: me.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			console.error(error)
 			await interaction.editReply({ embeds: [embed] })
 		}

--- a/src/commands/Admin/inactives.ts
+++ b/src/commands/Admin/inactives.ts
@@ -13,11 +13,12 @@ const command: Command = {
 		if (!interaction.inCachedGuild()) return
 
 		await inactives()
-		const embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor("Inactive checker")
-			.setTitle("All inactive members have been notified!")
-			.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: "Inactive checker" },
+			title: "All inactive members have been notified!",
+			footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		await interaction.reply({ embeds: [embed] })
 	}
 }

--- a/src/commands/Admin/members.ts
+++ b/src/commands/Admin/members.ts
@@ -32,7 +32,7 @@ const command: Command = {
 		if (color === "#000000") color = "BLURPLE"
 		if (maxMembersArr.length > 1) {
 			let page = 0,
-				pageEmbed = updatePage(maxMembersArr[page], page),
+				pageEmbed = updatePage(maxMembersArr[page], page + 1),
 				controlButtons = new MessageActionRow({
 					components: [
 						new MessageButton({
@@ -79,7 +79,7 @@ const command: Command = {
 					if (page > maxMembersArr.length - 1) page = maxMembersArr.length - 1
 				}
 				controlButtons = updateButtonColors(controlButtons, page, maxMembersArr)
-				pageEmbed = updatePage(maxMembersArr[page], page)
+				pageEmbed = updatePage(maxMembersArr[page], page + 1)
 				await buttonInteraction.update({ embeds: [pageEmbed], components: [controlButtons] })
 			})
 
@@ -97,7 +97,10 @@ const command: Command = {
 					author: { name: "Members list" },
 					title: `Here are all the ${tags.length} members with the ${role.name} role on the server at the moment.`,
 					description: membersArr.join(", "),
-					footer: { text: `${page !== undefined ? `Page ${page + 1}/${maxMembersArr.length}` : generateTip()}`, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+					footer: {
+						text: `${page ? `Page ${page}/${maxMembersArr.length}` : generateTip()}`,
+						iconURL: member.displayAvatarURL({ format: "png", dynamic: true })
+					}
 				})
 			} else {
 				return new MessageEmbed({

--- a/src/commands/Admin/members.ts
+++ b/src/commands/Admin/members.ts
@@ -33,26 +33,36 @@ const command: Command = {
 		if (maxMembersArr.length > 1) {
 			let page = 0,
 				pageEmbed = updatePage(maxMembersArr[page], page),
-				controlButtons = new MessageActionRow()
-					.addComponents(
-						new MessageButton()
-							.setEmoji("⏮️")
-							.setCustomId("first")
-							.setLabel("First page"),
-						new MessageButton()
-							.setEmoji("◀️")
-							.setCustomId("previous")
-							.setLabel("Previous page"),
-						new MessageButton()
-							.setEmoji("▶️")
-							.setCustomId("next")
-							.setLabel("Next page"),
-						new MessageButton()
-							.setEmoji("⏭️")
-							.setCustomId("last")
-							.setLabel("Last page")
-					)
-			controlButtons = updateButtonColors(controlButtons, page, maxMembersArr)
+				controlButtons = new MessageActionRow({
+					components: [
+						new MessageButton({
+							style: "SECONDARY",
+							emoji: "⏮️",
+							customId: "first",
+							label: "First page",
+							disabled: true
+						}),
+						new MessageButton({
+							style: "SUCCESS",
+							emoji: "◀️",
+							customId: "previous",
+							label: "Previous page",
+						}),
+						new MessageButton({
+							style: "SUCCESS",
+							emoji: "▶️",
+							customId: "next",
+							label: "Next page",
+						}),
+						new MessageButton({
+							style: "SECONDARY",
+							emoji: "⏭️",
+							customId: "last",
+							label: "Last page",
+							disabled: true
+						})
+					]
+				})
 			const msg = await interaction.reply({ embeds: [pageEmbed], components: [controlButtons], fetchReply: true }),
 				collector = msg.createMessageComponentCollector<"BUTTON">({ idle: 60_000 })
 
@@ -82,18 +92,20 @@ const command: Command = {
 
 		function updatePage(membersArr: GuildMember[], page?: number) {
 			if (membersArr?.length) {
-				return new MessageEmbed()
-					.setColor(color)
-					.setAuthor("Members list")
-					.setTitle(`Here are all the ${tags.length} members with the ${role.name} role on the server at the moment.`)
-					.setDescription(membersArr.join(", "))
-					.setFooter(`${page !== undefined ? `Page ${page + 1}/${maxMembersArr.length}` : generateTip()}`, member.displayAvatarURL({ format: "png", dynamic: true }))
+				return new MessageEmbed({
+					color,
+					author: { name: "Members list" },
+					title: `Here are all the ${tags.length} members with the ${role.name} role on the server at the moment.`,
+					description: membersArr.join(", "),
+					footer: { text: `${page !== undefined ? `Page ${page + 1}/${maxMembersArr.length}` : generateTip()}`, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 			} else {
-				return new MessageEmbed()
-					.setColor(color)
-					.setAuthor("Members list")
-					.setTitle(`There are no members with the ${role.name} role on the server at the moment.`)
-					.setFooter(generateTip(), member.displayAvatarURL({ format: "png", dynamic: true }))
+				return new MessageEmbed({
+					color,
+					author: { name: "Members list" },
+					title: `There are no members with the ${role.name} role on the server at the moment.`,
+					footer: { text: generateTip(), iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 			}
 		}
 	}

--- a/src/commands/Admin/newlang.ts
+++ b/src/commands/Admin/newlang.ts
@@ -120,17 +120,18 @@ const command: Command = {
 			permissionOverwrites: pfOverwrites,
 			reason: `Added language ${language.name}`
 		})
-		const embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor("Channel creator")
-			.setTitle(`Successfully created the new ${country} category, channels and roles!`)
-			.setDescription("Make sure their names were set correctly, put them in their correct positions, check the role colors and don't forget to translate the channel topic!")
-			.addFields(
+		const embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: "Channel creator" },
+			title: `Successfully created the new ${country} category, channels and roles!`,
+			description: "Make sure their names were set correctly, put them in their correct positions, check the role colors and don't forget to translate the channel topic!",
+			fields: [
 				{ name: "Text Channels", value: `${translatorsChannel} and ${proofreadersChannel}` },
 				{ name: "Voice Channels", value: `${translatorsVoice} and ${proofreadersVoice}` },
 				{ name: "Roles", value: `${translatorRole} and ${proofreaderRole}` }
-			)
-			.setFooter(generateTip(), member.displayAvatarURL({ format: "png", dynamic: true }))
+			],
+			footer: { text: generateTip(), iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		await interaction.editReply({ embeds: [embed] })
 	}
 }

--- a/src/commands/Admin/restart.ts
+++ b/src/commands/Admin/restart.ts
@@ -1,5 +1,4 @@
 import process from "node:process"
-import { setTimeout } from "node:timers/promises"
 import { MessageEmbed } from "discord.js"
 import { colors, ids } from "../../config.json"
 import { generateTip, restart } from "../../lib/util"
@@ -14,13 +13,13 @@ const command: Command = {
 	async execute(interaction) {
 		if (!interaction.inCachedGuild()) return
 		const member = interaction.member,
-			embed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor("Restart")
-				.setTitle("Restarting...")
-				.setFooter(generateTip(), member.displayAvatarURL({ format: "png", dynamic: true }))
+			embed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Restart" },
+				title: "Restarting...",
+				footer: { text: generateTip(), iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 		await interaction.reply({ embeds: [embed] })
-		await setTimeout(1000)
 		if (process.env.NODE_ENV === "production") await restart(interaction)
 		else process.exit()
 	}

--- a/src/commands/Admin/role.ts
+++ b/src/commands/Admin/role.ts
@@ -34,13 +34,13 @@ const command: Command = {
                 }
             else if (role.tags.premiumSubscriberRole) tags = { name: "Premium Subscriber Role", value: "True", inline: true }
         }
-        const embed = new MessageEmbed()
-            .setColor(role.color || "BLURPLE")
-            .setThumbnail(role.iconURL({ format: "png", size: 4096 }) ?? "")
-            .setAuthor("Role information")
-            .setTitle(`${role.name} ${role.unicodeEmoji ?? ""}`)
-            .setDescription(`${role} (ID: ${role.id})`)
-            .addFields(
+        const embed = new MessageEmbed({
+            color: role.color || "BLURPLE",
+            thumbnail: { url: role.iconURL({ format: "png", size: 4096 }) ?? "" },
+            author: { name: "Role information"},
+            title: `${role.name} ${role.unicodeEmoji ?? ""}`,
+            description: `${role} (ID: ${role.id})`,
+            fields: [
                 { name: "Mentionable", value: role.mentionable ? "Yes" : "No", inline: true },
                 { name: "Hoisted", value: role.hoist ? "Yes" : "No", inline: true },
                 { name: "Created at", value: `<t:${createdAt}:F> (<t:${createdAt}:R>)`, inline: true },
@@ -50,8 +50,9 @@ const command: Command = {
                 { name: "HEX color", value: role.hexColor, inline: true },
 
                 { name: "Permissions", value: permissions.includes("ADMINISTRATOR") ? "ADMINISTRATOR" : permissions.join(", ") || "None" }
-            )
-            .setFooter(generateTip(), member.displayAvatarURL({ format: "png", dynamic: true }))
+            ],
+            footer: { text: generateTip(), iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+        })
         if (tags) embed.spliceFields(5, 1, tags)
 
         await interaction.reply({ embeds: [embed] })

--- a/src/commands/Admin/stats.ts
+++ b/src/commands/Admin/stats.ts
@@ -27,22 +27,19 @@ const command: Command = {
 		const projectInput = interaction.options.getString("project", false)
 		if (!projectInput) {
 			await stats(true)
-				.then(async () => {
-					const allEmbed = new MessageEmbed()
-						.setColor(colors.success)
-						.setAuthor("Statistics updater")
-						.setTitle("All language statistics have been updated!")
-						.setDescription(
-							`Check them out at ${interaction.guild!.channels.cache.find(
-								c => c.name === "hypixel-language-status"
-							)}, ${interaction.guild!.channels.cache.find(c => c.name === "sba-language-status")}, ${interaction.guild!.channels.cache.find(
-								c => c.name === "bot-language-status"
-							)} and ${interaction.guild!.channels.cache.find(c => c.name === "quickplay-language-status")}`
-						)
-						.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
-					await interaction.editReply({ embeds: [allEmbed] })
-				})
 				.catch(err => { throw err })
+			const allEmbed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Statistics updater" },
+				title: "All statistics channels have been updated!",
+				description: `Check them out at ${interaction.guild!.channels.cache.find(
+					c => c.name === "hypixel-language-status"
+				)}, ${interaction.guild!.channels.cache.find(c => c.name === "sba-language-status")}, ${interaction.guild!.channels.cache.find(
+					c => c.name === "bot-language-status"
+				)} and ${interaction.guild!.channels.cache.find(c => c.name === "quickplay-language-status")}`,
+				footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
+			await interaction.editReply({ embeds: [allEmbed] })
 		} else {
 			switch (projectInput) {
 				case "hypixel": {
@@ -62,12 +59,13 @@ const command: Command = {
 					break
 				}
 			}
-			const projectEmbed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor("Statistics updater")
-				.setTitle(`The ${projectInput} language statistics have been updated!`)
-				.setDescription(`Check it out at ${interaction.guild!.channels.cache.find(c => c.name === `${projectInput}-language-status`)}!`)
-				.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const projectEmbed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Statistics updater" },
+				title: `The ${projectInput} language statistics have been updated!`,
+				description: `Check them out at ${interaction.guild!.channels.cache.find(c => c.name === `${projectInput}-language-status`)}!`,
+				footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			await interaction.editReply({ embeds: [projectEmbed] })
 			console.log(`Manually updated the ${projectInput} language statistics.`)
 		}

--- a/src/commands/Info/feedback.ts
+++ b/src/commands/Info/feedback.ts
@@ -14,20 +14,23 @@ const command: Command = {
 		const randomTip = generateTip(getString),
 			member = interaction.member as GuildMember | null ?? interaction.user
 
-		const embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor(getString("moduleName"))
-			.setTitle(getString("bugT"))
-			.setDescription(getString("bugD"))
-			.addField(getString("urgentT"), getString("urgentD"))
-			.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
-		const row = new MessageActionRow()
-			.addComponents(
-				new MessageButton()
-					.setLabel(getString("link"))
-					.setStyle("LINK")
-					.setURL("https://github.com/Hypixel-Translators/hypixel-translators-bot/issues")
-			)
+		const embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: getString("moduleName") },
+			title: getString("bugT"),
+			description: getString("bugD"),
+			fields: [{ name: getString("urgentT"), value: getString("urgentD") }],
+			footer: { text: randomTip, iconURL: member?.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
+		const row = new MessageActionRow({
+			components: [
+				new MessageButton({
+					style: "LINK",
+					label: getString("link"),
+					url: "https://github.com/Hypixel-Translators/hypixel-translators-bot/issues"
+				})
+			]
+		})
 		await interaction.reply({ components: [row], embeds: [embed] })
 	}
 }

--- a/src/commands/Info/levels.ts
+++ b/src/commands/Info/levels.ts
@@ -41,38 +41,44 @@ const command: Command = {
 		else if (inputPage) page = inputPage - 1
 
 		if (page >= pages.length || page < 0) {
-			const embed = new MessageEmbed()
-				.setColor(colors.error)
-				.setAuthor(getString("moduleName"))
-				.setTitle(getString("pageTitle"))
-				.setDescription(getString("pageNotExist"))
-				.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: colors.error,
+				author: { name: getString("moduleName") },
+				title: getString("pageTitle"),
+				description: getString("pageNotExist"),
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			return await interaction.reply({ embeds: [embed] })
 		} else {
-			let controlButtons = new MessageActionRow()
-				.addComponents(
-					new MessageButton()
-						.setStyle("SUCCESS")
-						.setEmoji("⏮️")
-						.setCustomId("first")
-						.setLabel(getString("pagination.first", "global")),
-					new MessageButton()
-						.setStyle("SUCCESS")
-						.setEmoji("◀️")
-						.setCustomId("previous")
-						.setLabel(getString("pagination.previous", "global")),
-					new MessageButton()
-						.setStyle("SUCCESS")
-						.setEmoji("▶️")
-						.setCustomId("next")
-						.setLabel(getString("pagination.next", "global")),
-					new MessageButton()
-						.setStyle("SUCCESS")
-						.setEmoji("⏭️")
-						.setCustomId("last")
-						.setLabel(getString("pagination.last", "global"))
-				),
-				pageEmbed: MessageEmbed = fetchPage(page, pages, getString, interaction)
+			let controlButtons = new MessageActionRow({
+				components: [
+					new MessageButton({
+						style: "SUCCESS",
+						emoji: "⏮️",
+						customId: "first",
+						label: getString("pagination.first", "global")
+					}),
+					new MessageButton({
+						style: "SUCCESS",
+						emoji: "◀️",
+						customId: "previous",
+						label: getString("pagination.previous", "global")
+					}),
+					new MessageButton({
+						style: "SUCCESS",
+						emoji: "▶️",
+						customId: "next",
+						label: getString("pagination.next", "global")
+					}),
+					new MessageButton({
+						style: "SUCCESS",
+						emoji: "⏭️",
+						customId: "last",
+						label: getString("pagination.last", "global")
+					})
+				]
+			}),
+				pageEmbed = fetchPage(page, pages, getString, interaction)
 
 			controlButtons = updateButtonColors(controlButtons, page, pages)
 			const msg = await interaction.reply({ embeds: [pageEmbed], components: [controlButtons], fetchReply: true }) as Message,
@@ -108,14 +114,16 @@ const command: Command = {
 function fetchPage(page: number, pages: DbUser[][], getString: GetStringFunction, interaction: CommandInteraction) {
 	if (page > pages.length - 1) page = pages.length - 1
 	if (page < 0) page = 0
-	const pageEmbed = new MessageEmbed()
-		.setColor(colors.neutral)
-		.setAuthor(getString("moduleName"))
-		.setTitle(getString("pageTitle"))
-		.setFooter(
-			getString("pagination.page", { number: page + 1, total: pages.length }, "global"),
-			(interaction.member as GuildMember | null ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-		)
+	const pageEmbed = new MessageEmbed({
+		color: colors.neutral,
+		author: { name: getString("moduleName") },
+		title: getString("pageTitle"),
+		footer: {
+			text: getString("pagination.page", { number: page + 1, total: pages.length }, "global"),
+			iconURL:
+				((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+		}
+	})
 	for (let i = 0; i <= pages[page].length - 1; i++) {
 		// const user = interaction.client.users.cache.get(pages[page][i].id)! //Get the user if we ever decide to change that
 		if (pages[page][i].levels) {

--- a/src/commands/Info/ping.ts
+++ b/src/commands/Info/ping.ts
@@ -28,17 +28,16 @@ const command: Command = {
 		else
 			color = colors.error
 
-		const embed = new MessageEmbed()
-			.setColor(color)
-			.setAuthor(getString("moduleName"))
-			.setTitle(getString("pong", { pingEmote: "<:ping:620954198493888512>" }))
-			.setDescription(
-				`${getString("message", { ping: ping })}\n\n${getString("onlineSince", {
-					timestamp: `<t:${onlineSince}>`,
-					timestampRelative: `<t:${onlineSince}:R>`
-				})}`
-			)
-			.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color,
+			author: { name: getString("moduleName") },
+			title: getString("pong", { pingEmote: "<:ping:620954198493888512>" }),
+			description: `${getString("message", { ping: ping })}\n\n${getString("onlineSince", {
+				timestamp: `<t:${onlineSince}>`,
+				timestampRelative: `<t:${onlineSince}:R>`
+			})}`,
+			footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		await interaction.reply({ embeds: [embed] })
 	}
 }

--- a/src/commands/Info/profile.ts
+++ b/src/commands/Info/profile.ts
@@ -31,42 +31,46 @@ const command: Command = {
 			if (!profile) {
 				const userDb = await client.getUser(user.id)
 				if (userDb.profile) {
-					const embed = new MessageEmbed()
-						.setColor(colors.neutral)
-						.setAuthor("Crowdin Profile")
-						.setTitle(`Here's ${user.tag}'s Crowdin profile`)
-						.setDescription(userDb.profile)
-						.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						color: colors.neutral,
+						author: { name: "Crowdin Profile" },
+						title: `Here's ${user.tag}'s Crowdin profile`,
+						description: userDb.profile,
+						footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+					})
 					return await interaction.reply({ embeds: [embed], ephemeral: true })
 				} else {
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor("Crowdin Profile")
-						.setTitle(`Couldn't find ${user.tag}'s Crowdin profile on the database!`)
-						.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						color: colors.error,
+						author: { name: "Crowdin Profile" },
+						title: `Couldn't find ${user.tag}'s Crowdin profile on the database!`,
+						footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+					})
 					return await interaction.reply({ embeds: [embed], ephemeral: true })
 				}
 			} else {
 				if (/(https:\/\/)?(www\.)?crowdin\.com\/profile\/\S{1,}/gi.test(profile)) {
 					const result = await collection.findOneAndUpdate({ id: user.id }, { $set: { profile: profile } })
 					if (result.value!.profile !== profile) {
-						const embed = new MessageEmbed()
-							.setColor(colors.success)
-							.setAuthor("User Profile")
-							.setTitle(`Successfully updated ${user.tag}'s Crowdin profile!`)
-							.addFields(
+						const embed = new MessageEmbed({
+							color: colors.success,
+							author: { name: "User Profile" },
+							title: `Successfully updated ${user.tag}'s Crowdin profile!`,
+							fields: [
 								{ name: "Old profile", value: result.value!.profile ?? "None" },
 								{ name: "New profile", value: profile }
-							)
-							.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+							],
+							footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+						})
 						return await interaction.reply({ embeds: [embed], ephemeral: true })
 					} else {
-						const embed = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor("User Profile")
-							.setTitle(`Couldn't update ${user.tag}'s Crowdin profile!`)
-							.setDescription("Their current profile is the same as the one you tried to add.")
-							.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+						const embed = new MessageEmbed({
+							color: colors.error,
+							author: { name: "User Profile" },
+							title: `Couldn't update ${user.tag}'s Crowdin profile!`,
+							description: "Their current profile is the same as the one you tried to add.",
+							footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+						})
 						return await interaction.reply({ embeds: [embed], ephemeral: true })
 					}
 				} else throw "wrongLink"
@@ -75,39 +79,43 @@ const command: Command = {
 			const profileUser = await db.collection<DbUser>("users").findOne({ profile: profile })
 			if (profileUser) {
 				const userObject = await client.users.fetch(profileUser.id),
-					embed = new MessageEmbed()
-						.setColor(colors.neutral)
-						.setAuthor("Crowdin Profile")
-						.setTitle(`That profile belongs to ${userObject.tag}`)
-						.setDescription(`${userObject}: ${profileUser.profile!}`)
-						.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					embed = new MessageEmbed({
+						color: colors.neutral,
+						author: { name: "Crowdin Profile" },
+						title: `That profile belongs to ${userObject.tag}`,
+						description: `${userObject}: ${profileUser.profile!}`,
+						footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+					})
 				return await interaction.reply({ embeds: [embed], ephemeral: true })
 			} else {
-				const embed = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor("Crowdin Profile")
-					.setTitle("Couldn't find a user with that profile!")
-					.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.neutral,
+					author: { name: "Crowdin Profile" },
+					title: "Couldn't find a user with that profile!",
+					footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.reply({ embeds: [embed], ephemeral: true })
 			}
 		} else {
 			const randomTip = generateTip(getString),
 				userDb = await client.getUser(interaction.user.id)
 			if (userDb.profile) {
-				const embed = new MessageEmbed()
-					.setColor(colors.neutral)
-					.setAuthor(getString("moduleName"))
-					.setTitle(getString("profileSuccess"))
-					.setDescription(userDb.profile)
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.neutral,
+					author: { name: getString("moduleName") },
+					title: getString("profileSuccess"),
+					description: userDb.profile,
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.reply({ embeds: [embed], ephemeral: true })
 			} else {
-				const embed = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor(getString("moduleName"))
-					.setTitle(getString("noProfile"))
-					.setDescription(getString("howStore"))
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.error,
+					author: { name: getString("moduleName") },
+					title: getString("noProfile"),
+					description: getString("howStore"),
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.reply({ embeds: [embed], ephemeral: true })
 			}
 		}

--- a/src/commands/Info/projects.ts
+++ b/src/commands/Info/projects.ts
@@ -33,12 +33,12 @@ const command: Command = {
 		if (member.roles.cache.find(role => role.name === "Bot Translator" || role.name === "Bot Proofreader" || role.name === "Bot Manager"))
 			joinedBot = `<:vote_yes:839262196797669427> **${getString("alreadyJoined")}**`
 		else joinedBot = `<:vote_no:839262184882044931> **${getString("notJoined")}**`
-		const embed = new MessageEmbed()
-			.setColor(colors.neutral)
-			.setAuthor(getString("moduleName"))
-			.setTitle(getString("allProjects"))
-			.setDescription(getString("description"))
-			.addFields(
+		const embed = new MessageEmbed({
+			color: colors.neutral,
+			author: { name: getString("moduleName") },
+			title: getString("allProjects"),
+			description: getString("description"),
+			fields: [
 				{
 					name: "Hypixel",
 					value: `${getString("projectInfo", {
@@ -71,8 +71,9 @@ const command: Command = {
 						command: "`/tag bot`"
 					})}\n${joinedBot}`
 				}
-			)
-			.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+			],
+			footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		await interaction.reply({ embeds: [embed] })
 	}
 }

--- a/src/commands/Info/rank.ts
+++ b/src/commands/Info/rank.ts
@@ -26,16 +26,16 @@ const command: Command = {
 
 		const userDb = await client.getUser(user.id)
 		if (!userDb.levels) {
-			const errorEmbed = new MessageEmbed()
-				.setColor(colors.error)
-				.setAuthor(getString("moduleName"))
-				.setTitle(user.id === interaction.user.id ? getString("youNotRanked") : getString("userNotRanked"))
-				.setDescription(getString("howRank"))
-				.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+			const errorEmbed = new MessageEmbed({
+				color: colors.error,
+				author: { name: getString("moduleName") },
+				title: user.id === interaction.user.id ? getString("youNotRanked") : getString("userNotRanked"),
+				description: getString("howRank"),
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			return await interaction.reply({ embeds: [errorEmbed] })
 		}
 		const totalXp = getXpNeeded(userDb.levels.level),
-			progressBar = generateProgressBar(userDb.levels.levelXp, totalXp),
 			ranking = (await collection.find({}, { sort: { "levels.totalXp": -1, "id": 1 } }).toArray()).map(u => u.id).indexOf(user.id) + 1,
 			currentXp = userDb.levels.levelXp,
 			messageCount = userDb.levels.messageCount
@@ -44,13 +44,19 @@ const command: Command = {
 			xpNeededFormatted = parseToNumberString(totalXp, getString),
 			messageCountFormatted = parseToNumberString(messageCount, getString)
 
-		const embed = new MessageEmbed()
-			.setColor(colors.neutral)
-			.setAuthor(getString("moduleName"))
-			.setTitle(user.id === interaction.user.id ? getString("yourRank") : getString("userRank", { user: user.tag }))
-			.setDescription(user.id === interaction.user.id ? getString("youLevel", { level: userDb.levels.level, rank: ranking }) : getString("userLevel", { user: String(user), level: userDb.levels.level, rank: ranking }))
-			.addField(getString("textProgress", { currentXp: currentXpFormatted, xpNeeded: xpNeededFormatted, messages: messageCountFormatted }), progressBar)
-			.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.neutral,
+			author: { name: getString("moduleName") },
+			title: user.id === interaction.user.id ? getString("yourRank") : getString("userRank", { user: user.tag }),
+			description: user.id === interaction.user.id
+				? getString("youLevel", { level: userDb.levels.level, rank: ranking })
+				: getString("userLevel", { user: `${user}`, level: userDb.levels.level, rank: ranking }),
+			fields: [{
+				name: getString("textProgress", { currentXp: currentXpFormatted, xpNeeded: xpNeededFormatted, messages: messageCountFormatted }),
+				value: generateProgressBar(userDb.levels.levelXp, totalXp),
+			}],
+			footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		await interaction.reply({ embeds: [embed] })
 	}
 }

--- a/src/commands/Info/translate.ts
+++ b/src/commands/Info/translate.ts
@@ -15,30 +15,32 @@ const command: Command = {
             member = interaction.client.guilds.cache.get("549503328472530974")!.members.resolve(interaction.user.id)!
 
         if (member.roles.cache.find(role => role.name.startsWith("Bot ") && role.name !== "Bot Updates")) {
-            const embed = new MessageEmbed()
-                .setColor(colors.neutral)
-                .setAuthor(getString("moduleName"))
-                .setTitle(getString("alreadyTranslator"))
-                .setDescription(getString("projectLink", { link: "https://crowdin.com/project/hypixel-translators-bot" }))
-                .addFields(
+            const embed = new MessageEmbed({
+                color: colors.neutral,
+                author: { name: getString("moduleName") },
+                title: getString("alreadyTranslator"),
+                description: getString("projectLink", { link: "https://crowdin.com/project/hypixel-translators-bot" }),
+                fields: [
                     { name: getString("question"), value: getString("askTranslators", { botTranslators: `<#${ids.channels.botTranslators}>` }) },
                     { name: getString("newCrowdin"), value: getString("checkGuide", { gettingStarted: `<#${ids.channels.gettingStarted}>` }) }
-                )
-                .setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+                ],
+                footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+            })
             await interaction.reply({ embeds: [embed] })
         } else {
-            const embed = new MessageEmbed()
-                .setColor(colors.neutral)
-                .setAuthor(getString("moduleName"))
-                .setTitle(getString("newTranslator"))
-                .setDescription(getString("join"))
-                .addFields(
+            const embed = new MessageEmbed({
+                color: colors.neutral,
+                author: { name: getString("moduleName") },
+                title: getString("newTranslator"),
+                description: getString("join"),
+                fields: [
                     { name: getString("openProject"), value: getString("howOpen", { link: "https://crowdin.com/project/hypixel-translators-bot" }) },
                     { name: getString("clickLanguage"), value: getString("requestJoin") },
                     { name: getString("lastThing"), value: getString("requestInfo", { tag: interaction.user.tag, id: interaction.user.id }) },
                     { name: getString("noLanguage"), value: getString("langRequest") }
-                )
-                .setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+                ],
+                footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+            })
             await interaction.reply({ embeds: [embed] })
         }
     }

--- a/src/commands/Staff/case.ts
+++ b/src/commands/Staff/case.ts
@@ -26,12 +26,13 @@ const command: Command = {
 		if (!modLog) throw `Couldn't find that case number! You must enter a number between 1 and ${await collection.estimatedDocumentCount()}`
 
 		const offender = interaction.guild!.members.cache.get(modLog.id) ?? await interaction.client.users.fetch(modLog.id),
-			embed = new MessageEmbed()
-				.setColor("BLURPLE")
-				.setAuthor("Punishment case")
-				.setTitle(`Here's case #${caseNumber}`)
-				.setDescription(`Offender: ${offender instanceof GuildMember ? offender : offender.tag}`)
-				.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			embed = new MessageEmbed({
+				color: "BLURPLE",
+				author: { name: "Punishment case" },
+				title: `Here's case #${caseNumber}`,
+				description: `Offender: ${offender instanceof GuildMember ? offender : offender.tag}`,
+				footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 		updateModlogFields(embed, modLog)
 		await interaction.reply({ embeds: [embed] })
 	}

--- a/src/commands/Staff/check.ts
+++ b/src/commands/Staff/check.ts
@@ -42,18 +42,19 @@ const command: Command = {
 			userRoles = rolesCache.sort((a, b) => b.position - a.position).map(r => r).join(", ")
 		} else userRoles = "No roles yet!"
 
-		const embed = new MessageEmbed()
-			.setColor(color)
-			.setAuthor({ name: "User information", iconURL: memberInput.user.displayAvatarURL({ format: "png", dynamic: true }) })
-			.setTitle(memberInput.user.tag)
-			.setDescription(`${memberInput} (ID: ${memberInput.id})`)
-			.addFields(
+		const embed = new MessageEmbed({
+			color,
+			author: { name: "User information", iconURL: memberInput.user.displayAvatarURL({ format: "png", dynamic: true }) },
+			title: memberInput.user.tag,
+			description: `${memberInput} (ID: ${memberInput.id})`,
+			fields: [
 				{ name: "Joined on", value: `<t:${joinedAgo}:F> (<t:${joinedAgo}:R>)`, inline: true },
 				{ name: "Account created on", value: `<t:${createdAgo}:F> (<t:${createdAgo}:R>)`, inline: true },
 				{ name: "Roles", value: userRoles },
-			)
-			.setThumbnail(memberInput.user.displayAvatarURL({ format: "png", dynamic: true }))
-			.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			],
+			thumbnail: { url: memberInput.displayAvatarURL({ format: "png", dynamic: true }) },
+			footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+		})
 		if (note) embed.addField("Note", note)
 		await interaction.reply({ embeds: [embed] })
 	}

--- a/src/commands/Staff/dm.ts
+++ b/src/commands/Staff/dm.ts
@@ -27,29 +27,32 @@ const command: Command = {
 		const recipient = interaction.options.getUser("user", true),
 			recipientDb = await client.getUser(recipient.id),
 			message = interaction.options.getString("message", true).replaceAll("\\n", "\n"),
-			dm = new MessageEmbed()
-				.setColor(colors.neutral)
-				.setAuthor(getString("incoming", this.name, recipientDb.lang))
-				.setDescription(message)
-				.setFooter(getString("incomingDisclaimer", this.name, recipientDb.lang)),
+			dm = new MessageEmbed({
+				color: colors.neutral,
+				author: getString("incoming", this.name, recipientDb.lang),
+				description: message,
+				footer: { text: getString("incomingDisclaimer", this.name, recipientDb.lang) }
+			}),
 			randomTip = generateTip()
 		await recipient.send({ embeds: [dm] })
 			.then(async () => {
-				const embed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor("Direct Message")
-					.setTitle(`Sent message to ${recipient.tag}`)
-					.setDescription(message)
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.success,
+					author: { name: "Direct Message" },
+					title: `Sent message to ${recipient.tag}`,
+					description: message,
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				await interaction.editReply({ embeds: [embed] })
 			})
 			.catch(async error => {
-				const errorEmbed = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor("Direct Message")
-					.setTitle(`An error occured while trying to message ${recipient.tag}`)
-					.setDescription(error.toString())
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const errorEmbed = new MessageEmbed({
+					color: colors.error,
+					author: { name: "Direct Message" },
+					title: `An error occured while trying to message ${recipient.tag}`,
+					description: `${error}`,
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				await interaction.editReply({ embeds: [errorEmbed] })
 			})
 	}

--- a/src/commands/Staff/loa.ts
+++ b/src/commands/Staff/loa.ts
@@ -98,6 +98,7 @@ const command: Command = {
 			extraInfo = interaction.options.getString("extrainfo", false),
 			startDate = new Date(startYear, startMonth - 1, startDay),
 			endDate = new Date(endYear, endMonth - 1, endDay),
+			//I promise this makes sense
 			today = new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate())
 
 		if (startDay > 31 || endDay > 31)
@@ -109,24 +110,27 @@ const command: Command = {
 		else if (endDate.getTime() <= today.getTime() || startDate.getTime() <= today.getTime())
 			return await interaction.reply({ content: "The end and start date must both be after today!", ephemeral: true })
 
-		const embed = new MessageEmbed()
-			.setColor("BLURPLE")
-			.setAuthor({ name: interaction.user.tag, iconURL: interaction.member.displayAvatarURL() })
-			.setTitle(`${interaction.member.displayName} is going away for some time!`)
-			.addFields(
+		const embed = new MessageEmbed({
+			color: "BLURPLE",
+			author: { name: interaction.user.tag, iconURL: interaction.member.displayAvatarURL() },
+			title: `${interaction.member.displayName} is going away for some time!`,
+			fields: [
 				{ name: "From", value: `${startDay}/${startMonth}/${startYear}` },
 				{ name: "To", value: `${endDay}/${endMonth}/${endYear}` },
 				{ name: "Reason", value: reason }
-			)
+			]
+		})
 		if (extraInfo) embed.addField("Extra info", extraInfo)
-		const doneRow = new MessageActionRow()
-			.addComponents(
-				new MessageButton()
-					.setStyle("SUCCESS")
-					.setLabel("End LOA")
-					.setEmoji("✅")
-					.setCustomId("done")
-			)
+		const doneRow = new MessageActionRow({
+			components: [
+				new MessageButton({
+					style: "SUCCESS",
+					label: "End LOA",
+					emoji: "✅",
+					customId: "done"
+				})
+			]
+		})
 		await loaChannel.send({ content: interaction.user.toString(), embeds: [embed], components: [doneRow] })
 		await interaction.reply({ content: `Successfully reported your LOA in ${loaChannel}! Once it's over, please delete it by clicking the button on the message.`, ephemeral: true })
 	}

--- a/src/commands/Staff/modlogs.ts
+++ b/src/commands/Staff/modlogs.ts
@@ -33,7 +33,7 @@ const command: Command = {
 		} else if (modlogs.length === 1) {
 			const embed = new MessageEmbed({
 				color: colors.success,
-				author: { name: "Log message", url: `https://discord.com/channels/549503328472530974/800820574405656587/${modlogs[0].logMsg}` },
+				author: { name: "Log message", url: `https://discord.com/channels/${ids.guilds.main}/${ids.channels.punishments}/${modlogs[0].logMsg}` },
 				title: `Found 1 modlog for ${userInput.tag}`,
 				description: `Case #${modlogs[0].case}`,
 				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
@@ -43,7 +43,7 @@ const command: Command = {
 		} else {
 			const embed = new MessageEmbed({
 				color: colors.success,
-				author: { name: "Log message", url: `https://discord.com/channels/549503328472530974/800820574405656587/${modlogs[0].logMsg}` },
+				author: { name: "Log message", url: `https://discord.com/channels/${ids.guilds.main}/${ids.channels.punishments}/${modlogs[0].logMsg}` },
 				title: `Found ${modlogs.length} modlogs for ${userInput.tag}`,
 				description: `Case #${modlogs[0].case}`,
 				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }

--- a/src/commands/Staff/modlogs.ts
+++ b/src/commands/Staff/modlogs.ts
@@ -23,47 +23,62 @@ const command: Command = {
 			randomTip = generateTip()
 
 		if (!modlogs.length) {
-			const embed = new MessageEmbed()
-				.setColor("BLURPLE")
-				.setAuthor("Modlogs")
-				.setTitle(`Couldn't find any modlogs for ${userInput.tag}`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: "BLURPLE",
+				author: { name: "Modlogs" },
+				title: `Couldn't find any modlogs for ${userInput.tag}`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			await interaction.reply({ embeds: [embed] })
 		} else if (modlogs.length === 1) {
-			const embed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor({ name: "Log message", url: `https://discord.com/channels/549503328472530974/800820574405656587/${modlogs[0].logMsg}` })
-				.setTitle(`Found 1 modlog for ${userInput.tag}`)
-				.setDescription(`Case #${modlogs[0].case}`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Log message", url: `https://discord.com/channels/549503328472530974/800820574405656587/${modlogs[0].logMsg}` },
+				title: `Found 1 modlog for ${userInput.tag}`,
+				description: `Case #${modlogs[0].case}`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			updateModlogFields(embed, modlogs[0])
 			await interaction.reply({ embeds: [embed] })
 		} else {
-			const embed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor({ name: "Log message", url: `https://discord.com/channels/549503328472530974/800820574405656587/${modlogs[0].logMsg}` })
-				.setTitle(`Found ${modlogs.length} modlogs for ${userInput.tag}`)
-				.setDescription(`Case #${modlogs[0].case}`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true })),
-				controlButtons = new MessageActionRow()
-					.addComponents(
-						new MessageButton()
-							.setEmoji("⏮️")
-							.setCustomId("first")
-							.setLabel("First log"),
-						new MessageButton()
-							.setEmoji("◀️")
-							.setCustomId("previous")
-							.setLabel("Previous log"),
-						new MessageButton()
-							.setEmoji("▶️")
-							.setCustomId("next")
-							.setLabel("Next log"),
-						new MessageButton()
-							.setEmoji("⏭️")
-							.setCustomId("last")
-							.setLabel("Last log")
-					)
+			const embed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Log message", url: `https://discord.com/channels/549503328472530974/800820574405656587/${modlogs[0].logMsg}` },
+				title: `Found ${modlogs.length} modlogs for ${userInput.tag}`,
+				description: `Case #${modlogs[0].case}`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			}),
+				controlButtons = new MessageActionRow({
+					components: [
+						new MessageButton({
+							style: "SECONDARY",
+							emoji: "⏮️",
+							customId: "first",
+							label: "First log",
+							disabled: true
+						}),
+						new MessageButton({
+							style: "SUCCESS",
+							emoji: "◀️",
+							customId: "previous",
+							label: "Previous log",
+						}),
+						new MessageButton({
+							style: "SUCCESS",
+							emoji: "▶️",
+							customId: "next",
+							label: "Next log",
+						}),
+						new MessageButton({
+							style: "SECONDARY",
+							emoji: "⏭️",
+							customId: "last",
+							label: "Last log",
+							disabled: true
+						})
+					]
+				})
+
 			let log = 0
 			updateButtonColors(controlButtons, log, modlogs)
 			updateModlogFields(embed, modlogs[0], modlogs)

--- a/src/commands/Staff/punishment.ts
+++ b/src/commands/Staff/punishment.ts
@@ -486,15 +486,14 @@ const command: Command = {
 					const dmEmbed = new MessageEmbed({
 						color: colors.error,
 						author: { name: "Punishments" },
-						title: `You have been ${punishment.duration ? "" : "permanently "}banned from the ${interaction.guild!.name} ${punishment.duration ? `for ${punishment.duration} days` : ""
-							}`,
+						title: `You have been ${punishment.duration ? "" : "permanently "}banned from the ${interaction.guild!.name} ${punishment.duration ? `for ${punishment.duration} days` : ""}`,
 						description: `**Reason:** ${reason}\n\n${endTimestamp
 							? `This ban will expire on <t:${Math.round(endTimestamp / 1000)}:F> (<t:${Math.round(
 								endTimestamp / 1000
 							)}:R>)`
 							: "This is a permanent ban and will not expire"
 							}`,
-						timestamp: Date.now(),
+						timestamp: Date.now()
 					}),
 						embed = new MessageEmbed({
 							color: colors.success,
@@ -508,9 +507,9 @@ const command: Command = {
 									value: `${punishment.duration ? `${punishment.duration!.toString()} days` : "Permanent"}`,
 									inline: true
 								},
-								{ name: "Reason", value: reason! },
+								{ name: "Reason", value: reason! }
 							],
-							footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+							footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
 						})
 					await user.send({ embeds: [dmEmbed] })
 						.then(async () => await buttonInteraction.editReply({ embeds: [embed], components: [] }))
@@ -699,7 +698,7 @@ const command: Command = {
 				const dmEmbed = new MessageEmbed({
 					color: colors.success,
 					author: { name: "Punishments" },
-					title: `You have been un ${activePunishments[0].type === "BAN" ? "banned" : "muted"} from the ${interaction.guild!.name}`,
+					title: `You have been un${activePunishments[0].type === "BAN" ? "banned" : "muted"} from the ${interaction.guild!.name}`,
 					description: `**Reason:** ${reason}`,
 					timestamp: Date.now()
 				}),

--- a/src/commands/Staff/punishment.ts
+++ b/src/commands/Staff/punishment.ts
@@ -124,21 +124,24 @@ const command: Command = {
 			points = interaction.options.getInteger("points", false) as PunishmentPoints | null,
 			duration = interaction.options.getNumber("duration", false),
 			punishment = await calculatePunishment(user, points ?? 1),
-			buttons = new MessageActionRow()
-				.addComponents(
-					new MessageButton()
-						.setCustomId("confirm")
-						.setLabel("Confirm")
-						.setStyle("SUCCESS")
-						.setEmoji("✅")
-						.setDisabled(),
-					new MessageButton()
-						.setCustomId("cancel")
-						.setLabel("Cancel")
-						.setStyle("DANGER")
-						.setEmoji("❎")
-						.setDisabled()
-				),
+			buttons = new MessageActionRow({
+				components: [
+					new MessageButton({
+						style: "SUCCESS",
+						customId: "confirm",
+						label: "Confirm",
+						emoji: "✅",
+						disabled: true
+					}),
+					new MessageButton({
+						style: "DANGER",
+						customId: "cancel",
+						label: "Cancel",
+						emoji: "❎",
+						disabled: true
+					})
+				]
+			}),
 			filter = (bInteraction: ButtonInteraction) => bInteraction.user.id === interaction.user.id,
 			caseNumber = (await collection.estimatedDocumentCount()) + 1,
 			punishmentsChannel = interaction.client.channels.cache.get(ids.channels.punishments) as TextChannel,
@@ -160,19 +163,20 @@ const command: Command = {
 			//Apply the punishment
 			if (punishment.type === "VERBAL") {
 				if (!memberInput) throw "Couldn't find that member! Are you sure they're on the server?"
-				const punishmentLog = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor({
+				const punishmentLog = new MessageEmbed({
+					color: colors.error,
+					author: {
 						name: `Case ${caseNumber} | Verbal Warning | ${points} point${points === 1 ? "" : "s"}`,
 						iconURL: user.displayAvatarURL({ format: "png", dynamic: true })
-					})
-					.addFields([
+					},
+					fields: [
 						{ name: "User", value: user.toString(), inline: true },
 						{ name: "Moderator", value: interaction.user.toString(), inline: true },
 						{ name: "Reason", value: reason! }
-					])
-					.setFooter(`ID: ${user.id}`)
-					.setTimestamp(),
+					],
+					footer: { text: `ID: ${user.id}` },
+					timestamp: Date.now()
+				}),
 					msg = await punishmentsChannel.send({ embeds: [punishmentLog] })
 
 				await collection.insertOne({
@@ -185,57 +189,61 @@ const command: Command = {
 					moderator: interaction.user.id,
 					logMsg: msg.id,
 				} as PunishmentLog)
-				const embed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor("Punishments")
-					.setTitle("Successfully registered this verbal warning!")
-					.addFields(
+				const embed = new MessageEmbed({
+					color: colors.success,
+					author: { name: "Punishments" },
+					title: "Successfully registered this verbal warning!",
+					fields: [
 						{ name: "Member", value: user.toString(), inline: true },
 						{ name: "Points", value: points!.toString(), inline: true },
 						{ name: "Reason", value: reason! }
-					)
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					],
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+				})
 				await interaction.editReply({ embeds: [embed] })
 			} else if (punishment.type === "WARN") {
-				const confirmEmbed = new MessageEmbed()
-					.setColor(colors.loading)
-					.setAuthor("Punishment")
-					.setTitle(`Are you sure you want to warn ${user.tag}?`)
-					.setDescription(reason!)
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
-				const msg = await interaction.editReply({ embeds: [confirmEmbed], components: [buttons] })
+				if (!memberInput) throw "Couldn't find that member! Are you sure they're on the server?"
+				const confirmEmbed = new MessageEmbed({
+					color: colors.loading,
+					author: { name: "Punishments" },
+					title: `Are you sure you want to warn ${user.tag}?`,
+					description: reason!,
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+				}),
+					msg = await interaction.editReply({ embeds: [confirmEmbed], components: [buttons] })
 
 				await setTimeout(5_000)
 				buttons.components.map(b => b.setDisabled(false))
 				await interaction.editReply({ components: [buttons] })
 				const buttonInteraction = await msg.awaitMessageComponent<"BUTTON">({ filter, time: 65_000 })
-					.catch(async () => {
-						const embed = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor("Punishments")
-							.setTitle("You didn't respond in time, so this user wasn't warned")
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
-						await interaction.editReply({ embeds: [embed], components: [] })
+					.catch(async () => null)
+				if (!buttonInteraction) {
+					const embed = new MessageEmbed({
+						color: colors.error,
+						author: { name: "Punishments" },
+						title: "You didn't respond in time, so this user wasn't warned",
+						footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
 					})
-				if (!buttonInteraction) return
+					await interaction.editReply({ embeds: [embed], components: [] })
+					return
+				}
 				if (buttonInteraction.customId === "confirm") {
 					await buttonInteraction.deferUpdate()
 
-					if (!memberInput) throw "Couldn't find that member! Are you sure they're on the server?"
-
-					const punishmentLog = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor({
+					const punishmentLog = new MessageEmbed({
+						color: colors.error,
+						author: {
 							name: `Case ${caseNumber} | Warning | ${points} point${points === 1 ? "" : "s"}`,
 							iconURL: user.displayAvatarURL({ format: "png", dynamic: true })
-						})
-						.addFields([
+						},
+						fields: [
 							{ name: "User", value: user.toString(), inline: true },
 							{ name: "Moderator", value: interaction.user.toString(), inline: true },
 							{ name: "Reason", value: reason! }
-						])
-						.setFooter(`ID: ${user.id}`)
-						.setTimestamp(),
+						],
+						footer: { text: `ID: ${user.id}` },
+						timestamp: Date.now()
+					}),
 						msg = await punishmentsChannel.send({ embeds: [punishmentLog] })
 
 					await collection.insertOne({
@@ -248,22 +256,24 @@ const command: Command = {
 						moderator: interaction.user.id,
 						logMsg: msg.id,
 					} as PunishmentLog)
-					const dmEmbed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor("Punishment")
-						.setTitle(`You have been warned on the ${interaction.guild!.name}`)
-						.setDescription(`**Reason:** ${reason}`)
-						.setTimestamp(),
-						embed = new MessageEmbed()
-							.setColor(colors.success)
-							.setAuthor("Punishments")
-							.setTitle("Successfully warned this member!")
-							.addFields(
+					const dmEmbed = new MessageEmbed({
+						color: colors.error,
+						author: { name: "Punishment" },
+						title: `You have been warned on the ${interaction.guild!.name}`,
+						description: `**Reason:** ${reason}`,
+						timestamp: Date.now()
+					}),
+						embed = new MessageEmbed({
+							color: colors.success,
+							author: { name: "Punishments" },
+							title: "Successfully warned this member!",
+							fields: [
 								{ name: "Member", value: user.toString(), inline: true },
 								{ name: "Points", value: points!.toString(), inline: true },
 								{ name: "Reason", value: reason! },
-							)
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+							],
+							footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+						})
 					await user.send({ embeds: [dmEmbed] })
 						.then(async () => await buttonInteraction.editReply({ embeds: [embed], components: [] }))
 						.catch(async err => {
@@ -274,52 +284,57 @@ const command: Command = {
 							await buttonInteraction.editReply({ embeds: [embed], components: [] })
 						})
 				} else if (buttonInteraction.customId === "cancel") {
-					const embed = new MessageEmbed()
-						.setColor(colors.success)
-						.setAuthor("Punishments")
-						.setTitle("Successfully cancelled this punishment")
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						color: colors.success,
+						author: { name: "Punishments" },
+						title: "Successfully cancelled this punishment",
+						footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+					})
 					await buttonInteraction.update({ embeds: [embed], components: [] })
 				}
 			} else if (punishment.type === "MUTE") {
-				const confirmEmbed = new MessageEmbed()
-					.setColor(colors.loading)
-					.setAuthor("Punishment")
-					.setTitle("Are you sure you want to mute this member?")
-					.setDescription(`Confirming this will mute ${user} for ${punishment.duration} hours with the following reason:\n\n${reason}`)
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const confirmEmbed = new MessageEmbed({
+					color: colors.loading,
+					author: { name: "Punishments" },
+					title: "Are you sure you want to mute this member?",
+					description: `Confirming this will mute ${user} for ${punishment.duration} hours with the following reason:\n\n${reason}`,
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+				})
 				const msg = await interaction.editReply({ embeds: [confirmEmbed], components: [buttons] })
 
 				await setTimeout(5_000)
 				buttons.components.map(b => b.setDisabled(false))
 				await interaction.editReply({ components: [buttons] })
 				const buttonInteraction = await msg.awaitMessageComponent<"BUTTON">({ filter, time: 65_000 })
-					.catch(async () => {
-						const embed = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor("Punishments")
-							.setTitle("You didn't respond in time, so this user wasn't muted")
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
-						await interaction.editReply({ embeds: [embed], components: [] })
+					.catch(async () => null)
+				if (!buttonInteraction) {
+					const embed = new MessageEmbed({
+						color: colors.error,
+						author: { name: "Punishments" },
+						title: "You didn't respond in time, so this user wasn't muted",
+						footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
 					})
-				if (!buttonInteraction) return
+					await interaction.editReply({ embeds: [embed], components: [] })
+					return
+				}
 				if (buttonInteraction.customId === "confirm") {
 					await buttonInteraction.deferUpdate()
 					const endTimestamp = new Date().setHours(new Date().getHours() + punishment.duration!),
-						punishmentLog = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor({
+						punishmentLog = new MessageEmbed({
+							color: colors.error,
+							author: {
 								name: `Case ${caseNumber} | Mute | ${points} point${points === 1 ? "" : "s"}`,
 								iconURL: user.displayAvatarURL({ format: "png", dynamic: true })
-							})
-							.addFields(
+							},
+							fields: [
 								{ name: "User", value: user.toString(), inline: true },
 								{ name: "Moderator", value: interaction.user.toString(), inline: true },
 								{ name: "Duration", value: `${punishment.duration} hours`, inline: true },
 								{ name: "Reason", value: reason! }
-							)
-							.setFooter(`ID: ${user.id}`)
-							.setTimestamp(),
+							],
+							footer: { text: `ID: ${user.id}` },
+							timestamp: Date.now()
+						}),
 						msg = await punishmentsChannel.send({ embeds: [punishmentLog] })
 
 					const punishmentDb = (await collection.insertOne({
@@ -341,23 +356,27 @@ const command: Command = {
 					if (memberInput.moderatable) await memberInput.disableCommunicationUntil(endTimestamp, `${reason} | ${interaction.user.tag}`)
 					else throw "I cannot mute that member!"
 
-					const dmEmbed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor("Punishment")
-						.setTitle(`You have been muted on the ${interaction.guild!.name} for ${punishment.duration} hours`)
-						.setDescription(`**Reason:** ${reason}\n\nYour mute will expire on <t:${Math.round(endTimestamp / 1000)}:F> (<t:${Math.round(endTimestamp / 1000)}:R>)`)
-						.setTimestamp(),
-						embed = new MessageEmbed()
-							.setColor(colors.success)
-							.setAuthor("Punishments")
-							.setTitle("Successfully muted this member!")
-							.addFields(
+					const dmEmbed = new MessageEmbed({
+						color: colors.error,
+						author: { name: "Punishment" },
+						title: `You have been muted on the ${interaction.guild!.name} for ${punishment.duration} hours`,
+						description: `**Reason:** ${reason}\n\nYour mute will expire on <t:${Math.round(
+							endTimestamp / 1000
+						)}:F> (<t:${Math.round(endTimestamp / 1000)}:R>)`,
+						timestamp: Date.now(),
+					}),
+						embed = new MessageEmbed({
+							color: colors.success,
+							author: { name: "Punishments" },
+							title: "Successfully muted this member!",
+							fields: [
 								{ name: "Member", value: user.toString(), inline: true },
 								{ name: "Points", value: points!.toString(), inline: true },
 								{ name: "Duration", value: `${punishment.duration!.toString()} hours`, inline: true },
-								{ name: "Reason", value: reason! },
-							)
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+								{ name: "Reason", value: reason! }
+							],
+							footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+						})
 					await user.send({ embeds: [dmEmbed] })
 						.then(async () => await buttonInteraction.editReply({ embeds: [embed], components: [] }))
 						.catch(async err => {
@@ -369,39 +388,43 @@ const command: Command = {
 						})
 					awaitMute(punishmentDb)
 				} else if (buttonInteraction.customId === "cancel") {
-					const embed = new MessageEmbed()
-						.setColor(colors.success)
-						.setAuthor("Punishments")
-						.setTitle("Successfully cancelled this punishment")
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						color: colors.success,
+						author: { name: "Punishments" },
+						title: "Successfully cancelled this punishment",
+						footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+					})
 					await buttonInteraction.update({ embeds: [embed], components: [] })
 				}
 			} else if (punishment.type === "BAN") {
-				const confirmEmbed = new MessageEmbed()
-					.setColor(colors.loading)
-					.setAuthor("Punishment")
-					.setTitle("Are you sure you want to ban this member?")
-					.setDescription(
-						`Confirming this will ban ${user} ${punishment.duration ? `for ${punishment.duration} days` : "permanently"
-						} with the following reason:\n\n${reason}${punishment.activePunishmentPoints ? "\n\n⚠ This user currently has an active punishment! Think twice before confirming this." : ""
-						}`
-					)
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const confirmEmbed = new MessageEmbed({
+					color: colors.loading,
+					author: { name: "Punishments" },
+					title: "Are you sure you want to ban this member?",
+					description: `Confirming this will ban ${user} ${punishment.duration ? `for ${punishment.duration} days` : "permanently"
+						} with the following reason:\n\n${reason}${punishment.activePunishmentPoints
+							? "\n\n⚠ This user currently has an active punishment! Think twice before confirming this."
+							: ""
+						}`,
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+				})
 				const msg = await interaction.editReply({ embeds: [confirmEmbed], components: [buttons] })
 
 				await setTimeout(5_000)
 				buttons.components.map(b => b.setDisabled(false))
 				await interaction.editReply({ components: [buttons] })
 				const buttonInteraction = await msg.awaitMessageComponent<"BUTTON">({ filter, time: 65_000 })
-					.catch(async () => {
-						const embed = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor("Punishments")
-							.setTitle("You didn't respond in time, so this user wasn't banned")
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
-						await interaction.editReply({ embeds: [embed], components: [] })
+					.catch(async () => null)
+				if (!buttonInteraction) {
+					const embed = new MessageEmbed({
+						color: colors.error,
+						author: { name: "Punishments" },
+						title: "You didn't respond in time, so this user wasn't banned",
+						footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
 					})
-				if (!buttonInteraction) return
+					await interaction.editReply({ embeds: [embed], components: [] })
+					return
+				}
 				if (buttonInteraction.customId === "confirm") {
 					await buttonInteraction.deferUpdate()
 
@@ -410,20 +433,21 @@ const command: Command = {
 					else throw "I cannot ban that member!"
 
 					const endTimestamp = punishment.duration ? new Date().setDate(new Date().getDate() + punishment.duration) : 0,
-						punishmentLog = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor({
+						punishmentLog = new MessageEmbed({
+							color: colors.error,
+							author: {
 								name: `Case ${caseNumber} | Ban | ${points} point${points === 1 ? "" : "s"}`,
 								iconURL: user.displayAvatarURL({ format: "png", dynamic: true })
-							})
-							.addFields(
+							},
+							fields: [
 								{ name: "User", value: user.toString(), inline: true },
 								{ name: "Moderator", value: interaction.user.toString(), inline: true },
 								{ name: "Duration", value: punishment.duration ? `${punishment.duration} days` : "Permanent", inline: true },
 								{ name: "Reason", value: reason! }
-							)
-							.setFooter(`ID: ${user.id}`)
-							.setTimestamp(),
+							],
+							footer: { text: `ID: ${user.id}` },
+							timestamp: Date.now()
+						}),
 						msg = await punishmentsChannel.send({ embeds: [punishmentLog] })
 
 					if (punishment.activePunishmentPoints)
@@ -459,28 +483,35 @@ const command: Command = {
 						logMsg: msg.id
 					}).then(result => collection.findOne({ _id: result.insertedId })))!
 
-					const dmEmbed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor("Punishment")
-						.setTitle(`You have been ${punishment.duration ? "" : "permanently "}banned from the ${interaction.guild!.name} ${punishment.duration ? `for ${punishment.duration} days` : ""}`)
-						.setDescription(
-							`**Reason:** ${reason}\n\n${endTimestamp
-								? `This ban will expire on <t:${Math.round(endTimestamp / 1000)}:F> (<t:${Math.round(endTimestamp / 1000)}:R>)`
-								: "This is a permanent ban and will not expire"
-							}`
-						)
-						.setTimestamp(),
-						embed = new MessageEmbed()
-							.setColor(colors.success)
-							.setAuthor("Punishments")
-							.setTitle("Successfully banned this member!")
-							.addFields(
+					const dmEmbed = new MessageEmbed({
+						color: colors.error,
+						author: { name: "Punishments" },
+						title: `You have been ${punishment.duration ? "" : "permanently "}banned from the ${interaction.guild!.name} ${punishment.duration ? `for ${punishment.duration} days` : ""
+							}`,
+						description: `**Reason:** ${reason}\n\n${endTimestamp
+							? `This ban will expire on <t:${Math.round(endTimestamp / 1000)}:F> (<t:${Math.round(
+								endTimestamp / 1000
+							)}:R>)`
+							: "This is a permanent ban and will not expire"
+							}`,
+						timestamp: Date.now(),
+					}),
+						embed = new MessageEmbed({
+							color: colors.success,
+							author: { name: "Punishments" },
+							title: "Successfully banned this member!",
+							fields: [
 								{ name: "Member", value: user.toString(), inline: true },
 								{ name: "Points", value: points!.toString(), inline: true },
-								{ name: "Duration", value: `${punishment.duration ? `${punishment.duration!.toString()} days` : "Permanent"}`, inline: true },
-								{ name: "Reason", value: reason! }
-							)
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+								{
+									name: "Duration",
+									value: `${punishment.duration ? `${punishment.duration!.toString()} days` : "Permanent"}`,
+									inline: true
+								},
+								{ name: "Reason", value: reason! },
+							],
+							footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+						})
 					await user.send({ embeds: [dmEmbed] })
 						.then(async () => await buttonInteraction.editReply({ embeds: [embed], components: [] }))
 						.catch(async err => {
@@ -492,11 +523,12 @@ const command: Command = {
 						})
 					awaitBan(punishmentDb)
 				} else if (buttonInteraction.customId === "cancel") {
-					const embed = new MessageEmbed()
-						.setColor(colors.success)
-						.setAuthor("Punishments")
-						.setTitle("Successfully cancelled this punishment")
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						color: colors.success,
+						author: { name: "Punishments" },
+						title: "Successfully cancelled this punishment",
+						footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+					})
 					await buttonInteraction.update({ embeds: [embed], components: [] })
 				}
 			}
@@ -507,11 +539,12 @@ const command: Command = {
 				activePoints = activePoints + (punishment.points ?? 0)
 			})
 
-			const embed = new MessageEmbed()
-				.setColor(activePoints ? colors.error : colors.success)
-				.setAuthor("Punishments")
-				.setTitle(`${user.tag} currently has ${activePoints} point${activePoints === 1 ? "" : "s"}.`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: activePoints ? colors.error : colors.success,
+				author: { name: "Punishments" },
+				title: `${user.tag} currently has ${activePoints} point${activePoints === 1 ? "" : "s"}.`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) },
+			})
 			activePunishments.forEach(punishment => {
 				const durationString = punishment.duration ? `${punishment.duration}${punishment.type === "BAN" ? "d" : "h"} ` : "permanent ",
 					expireTimestamp =
@@ -537,14 +570,17 @@ const command: Command = {
 				unexpiredPunishments = await getActivePunishments(user),
 				durationString = punishment.duration ? `${punishment.duration}${punishment.type === "BAN" ? "d" : "h"} ` : "permanent "
 
-			const embed = new MessageEmbed()
-				.setColor(hasPermission ? (colors.success) : (colors.error))
-				.setAuthor("Punishments")
-				.setTitle(`Giving this member ${points} points will result in a ${["MUTE", "BAN"].includes(punishment.type) ? durationString : ""}${punishment.type}`)
-				.setDescription(
-					`You ${hasPermission ? "" : "don't "}have permission to issue this punishment.\n\n${unexpiredPunishments.length ? `Here are ${user}'s active punishments:` : `${user} has no active punishments at the moment`}`
-				)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: hasPermission ? colors.success : colors.error,
+				author: { name: "Punishments" },
+				title: `Giving this member ${points} points will result in a ${["MUTE", "BAN"].includes(punishment.type) ? durationString : ""
+					}${punishment.type}`,
+				description: `You ${hasPermission ? "" : "don't "}have permission to issue this punishment.\n\n${unexpiredPunishments.length
+					? `Here are ${user}'s active punishments:`
+					: `${user} has no active punishments at the moment`
+					}`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			unexpiredPunishments.forEach(punishment => {
 				const durationString = punishment.duration ? `${punishment.duration}${punishment.type === "BAN" ? "d" : "h"} ` : "permanent ",
 					expireTimestamp =
@@ -580,11 +616,12 @@ const command: Command = {
 			activePunishments.forEach(punishment => {
 				activePoints = activePoints + (punishment.points ?? 0)
 			})
-			const embed = new MessageEmbed()
-				.setColor(colors.loading)
-				.setAuthor("Punishments")
-				.setTitle(`Are you sure you want to revoke ${user.tag}'s active ${activePunishments[0].type}?`)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: colors.loading,
+				author: { name: "Punishments" },
+				title: `Are you sure you want to revoke ${user.tag}'s active ${activePunishments[0].type}?`,
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			activePunishments.forEach(punishment => {
 				const durationString = punishment.duration ? `${punishment.duration}${punishment.type === "BAN" ? "d" : "h"} ` : "permanent ",
 					expireTimestamp =
@@ -610,59 +647,73 @@ const command: Command = {
 			buttons.components.map(b => b.setDisabled(false))
 			await interaction.editReply({ components: [buttons] })
 			const buttonInteraction = await msg.awaitMessageComponent<"BUTTON">({ filter, time: 65_000 })
-				.catch(async () => {
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor("Punishments")
-						.setTitle("You didn't respond in time, so this user's punishments weren't revoked")
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
-					await interaction.editReply({ embeds: [embed], components: [] })
+				.catch(async () => null)
+			if (!buttonInteraction) {
+				const embed = new MessageEmbed({
+					color: colors.error,
+					author: { name: "Punishments" },
+					title: "You didn't respond in time, so this user's punishments weren't revoked",
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
 				})
-			if (!buttonInteraction) return
+				await interaction.editReply({ embeds: [embed], components: [] })
+				return
+			}
 			if (buttonInteraction.customId === "confirm") {
 				await buttonInteraction.deferUpdate()
-				const punishmentLog = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor({
+				const punishmentLog = new MessageEmbed({
+					color: colors.success,
+					author: {
 						name: `Case ${caseNumber} | ${activePunishments[0].type === "BAN" ? "Unban" : "Unmute"} | ${user.tag}`,
 						iconURL: user.displayAvatarURL({ format: "png", dynamic: true })
-					})
-					.addFields([
-						{ name: "User", value: user.toString(), inline: true },
-						{ name: "Moderator", value: interaction.user.toString(), inline: true },
+					},
+					fields: [
+						{ name: "User", value: `${user}`, inline: true },
+						{ name: "Moderator", value: `${interaction.user}`, inline: true },
 						{ name: "Reason", value: reason! }
-					])
-					.setFooter(`ID: ${user.id}`)
-					.setTimestamp(),
+					],
+					footer: { text: `ID: ${user.id}` },
+					timestamp: Date.now()
+				}),
 					msg = await punishmentsChannel.send({ embeds: [punishmentLog] })
 
-				await collection.updateOne({ case: activePunishments[0].case }, { $set: { revoked: true, revokedBy: interaction.user.id, ended: true, endTimestamp: Date.now() } })
-				await collection.insertOne({
-					case: caseNumber,
-					id: user.id,
-					type: `UN${activePunishments[0].type}`,
-					reason,
-					timestamp: Date.now(),
-					moderator: interaction.user.id,
-					logMsg: msg.id
-				} as PunishmentLog)
+				await collection.bulkWrite([{
+					updateOne: {
+						filter: { case: activePunishments[0].case },
+						update: { $set: { revoked: true, revokedBy: interaction.user.id, ended: true, endTimestamp: Date.now() } }
+					}
+				},
+				{
+					insertOne: {
+						document: {
+							case: caseNumber,
+							id: user.id,
+							type: `UN${activePunishments[0].type}`,
+							reason,
+							timestamp: Date.now(),
+							moderator: interaction.user.id,
+							logMsg: msg.id
+						} as PunishmentLog
+					}
+				}])
 
-				const dmEmbed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor("Punishment")
-					.setTitle(`You have been un ${activePunishments[0].type === "BAN" ? "banned" : "muted"} from the ${interaction.guild!.name}`)
-					.setDescription(`**Reason:** ${reason}`)
-					.setTimestamp(),
-					embed = new MessageEmbed()
-						.setColor(colors.success)
-						.setAuthor("Punishments")
-						.setTitle("Successfully revoked this member's punishment!")
-						.addFields(
+				const dmEmbed = new MessageEmbed({
+					color: colors.success,
+					author: { name: "Punishments" },
+					title: `You have been un ${activePunishments[0].type === "BAN" ? "banned" : "muted"} from the ${interaction.guild!.name}`,
+					description: `**Reason:** ${reason}`,
+					timestamp: Date.now()
+				}),
+					embed = new MessageEmbed({
+						color: colors.success,
+						author: { name: "Punishments" },
+						title: "Successfully revoked this member's punishment!",
+						fields: [
 							{ name: "Member", value: user.toString(), inline: true },
 							{ name: "Punishment type", value: activePunishments[0].type, inline: true },
 							{ name: "Reason", value: reason!, inline: true }
-						)
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+						],
+						footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+					})
 
 				if (activePunishments[0].type === "BAN") await interaction.guild!.bans.remove(user.id, `${reason} | ${interaction.user.tag}`)
 					.catch(async err => {
@@ -683,11 +734,12 @@ const command: Command = {
 					})
 				else await buttonInteraction.editReply({ embeds: [embed], components: [] })
 			} else if (buttonInteraction.customId === "cancel") {
-				const embed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor("Punishments")
-					.setTitle("Successfully cancelled revoking this punishment")
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.success,
+					author: { name: "Punishments" },
+					title: "Successfully cancelled revoking this punishment",
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				await buttonInteraction.update({ embeds: [embed], components: [] })
 			}
 		}

--- a/src/commands/Staff/say.ts
+++ b/src/commands/Staff/say.ts
@@ -31,12 +31,13 @@ const command: Command = {
 
 		if (interaction.member.permissions.has("MANAGE_ROLES")) await sendTo.send(message)
 		else await sendTo.send(Formatters.blockQuote(message))
-		const embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor("Message")
-			.setTitle("Success! Message sent.")
-			.setDescription(`${sendTo}:\n${message}`)
-			.setFooter(generateTip(), interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: "Message" },
+			title: "Success! Message sent.",
+			description: `${sendTo}:\n${message}`,
+			footer: { text: generateTip(), iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		await interaction.reply({ embeds: [embed] })
 	}
 }

--- a/src/commands/Utility/8ball.ts
+++ b/src/commands/Utility/8ball.ts
@@ -23,15 +23,16 @@ const command: Command = {
 			answerType = keys[keys.length * Math.random() << 0] as "positive" | "inconclusive" | "negative",
 			answers = getString(`answers.${answerType}`),
 			answer = answers[Math.floor(Math.random() * answers.length)],
-			embed = new MessageEmbed()
-				.setAuthor(getString("moduleName"))
-				.setTitle(answer)
-				.addField(getString("question"), interaction.options.getString("question", true))
-				.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
-		if (answerType === "positive") embed.setColor(colors.success)
-		else if (answerType === "inconclusive") embed.setColor(colors.loading)
-		else if (answerType === "negative") embed.setColor(colors.error)
-		else console.error("Help the 8ball answer type is weird")
+			color = answerType === "positive" ? colors.success : answerType === "inconclusive" ? colors.loading : colors.error,
+			embed = new MessageEmbed({
+				color,
+				author: { name: getString("moduleName") },
+				title: answer,
+				fields: [
+					{ name: getString("question"), value: interaction.options.getString("question", true)}
+				],
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 		await interaction.reply({ embeds: [embed] })
 	}
 }

--- a/src/commands/Utility/help.ts
+++ b/src/commands/Utility/help.ts
@@ -63,12 +63,16 @@ const command: Command = {
 			let page = 0
 			if (pageInput) page = pageInput
 
-			const page1 = new MessageEmbed()
-				.setColor("BLURPLE")
-				.setAuthor(getString("moduleName"))
-				.setTitle(`${pages[0].badge} ${getString("mainPage")}`)
-				.setDescription(getString("commandsListTooltip", { developer: client.users.cache.get(ids.users.rodry)!.toString(), github: "(https://github.com/Hypixel-Translators/hypixel-translators-bot)" }))
-				.setFooter(randomTip, (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+			const page1 = new MessageEmbed({
+				color: "BLURPLE",
+				author: { name: getString("moduleName") },
+				title: `${pages[0].badge} ${getString("mainPage")}`,
+				description: getString("commandsListTooltip", {
+					developer: client.users.cache.get(ids.users.rodry)!.toString(),
+					github: "(https://github.com/Hypixel-Translators/hypixel-translators-bot)"
+				}),
+				footer: { text: randomTip, iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			pages.forEach(page => {
 				if (page.number === 0) return
 				page1.addField(getString("pageNumber", { number: page.number, total: pages.length }), `${page.badge} ${getString(page.titleString)}`, true)
@@ -78,19 +82,19 @@ const command: Command = {
 
 			//Determine which page to use
 			let pageEmbed = fetchPage(page, pages, getString, interaction)!
-			const pageMenu = new MessageActionRow()
-				.addComponents(
-					new MessageSelectMenu()
-						.setCustomId("page")
-						.addOptions(
-							pages.map(p => ({
-								label: getString(p.titleString),
-								value: `${p.number}`,
-								emoji: p.badge,
-								default: p.number === page
-							}))
-						)
-				)
+			const pageMenu = new MessageActionRow({
+				components: [
+					new MessageSelectMenu({
+						customId: "page",
+						options: pages.map(p => ({
+							label: getString(p.titleString),
+							value: `${p.number}`,
+							emoji: p.badge,
+							default: p.number === page
+						}))
+					})
+				]
+			})
 
 			const msg = await interaction.reply({ embeds: [pageEmbed], components: [pageMenu], fetchReply: true }) as Message,
 				collector = msg.createMessageComponentCollector<"SELECT_MENU">({ idle: this.cooldown! * 1000 })
@@ -118,18 +122,22 @@ const command: Command = {
 			let cmdDesc: string | undefined = undefined
 			if (command.category !== "Admin" && command.category !== "Staff") {
 				cmdDesc = getString(`${command.name}.description`)
-			} else if (command.category === "Staff" && member?.roles.cache.has(ids.roles.staff) || command.category === "Admin" && member?.roles.cache.has(ids.roles.admin)) {
+			} else if (
+				(command.category === "Staff" && member?.roles.cache.has(ids.roles.staff)) ||
+				(command.category === "Admin" && member?.roles.cache.has(ids.roles.admin))
+			)
 				cmdDesc = command.description
-			}
+
 
 			if (command.dev && !member?.roles.cache.has(ids.roles.staff)) cmdDesc = getString("inDev")
 
-			const embed = new MessageEmbed()
-				.setColor("BLURPLE")
-				.setAuthor(getString("moduleName"))
-				.setTitle(getString("commandInfoFor") + `\`/${command.name}\``)
-				.setDescription(cmdDesc ?? getString("staffOnly"))
-				.setFooter(randomTip, (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: "BLURPLE",
+				author: { name: getString("moduleName") },
+				title: getString("commandInfoFor") + `\`/${command.name}\``,
+				description: cmdDesc ?? getString("staffOnly"),
+				footer: { text: randomTip, iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			if (cmdDesc !== getString("inDev")) {
 				if (command.cooldown) {
 					if (command.cooldown >= 120) embed.addField(getString("cooldownField"), `${command.cooldown / 60} ${getString("minutes")}`, true)
@@ -150,14 +158,17 @@ function fetchPage(page: number, pages: Page[], getString: GetStringFunction, in
 	if (pages[page]) {
 		if (pages[page].embed) pageEmbed = pages[page].embed!
 		else if (pages[page].commands) {
-			pageEmbed = new MessageEmbed()
-				.setColor("BLURPLE")
-				.setAuthor(getString("moduleName"))
-				.setTitle(`${pages[page].badge} ${getString(pages[page].titleString!)}`)
-				.setFooter(
-					getString("pagination.page", { number: page + 1, total: pages.length }, "global"),
-					((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-				)
+			pageEmbed = new MessageEmbed({
+				color: "BLURPLE",
+				author: { name: getString("moduleName") },
+				title: `${pages[page].badge} ${getString(pages[page].titleString!)}`,
+				footer: {
+					text: getString("pagination.page", {
+						number: page + 1, total: pages.length
+					}, "global"),
+					iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+				}
+			})
 			pages[page].commands!.forEach(command => pageEmbed!.addField(`\`/${command}\``, getString(`${command}.description`)))
 		} else return console.error(`Help page ${page} has no embed fields specified!`)
 	} else return console.error(`Tried accessing help page ${page} but it doesn't exist in the pages array!`)

--- a/src/commands/Utility/hypixelstats.ts
+++ b/src/commands/Utility/hypixelstats.ts
@@ -117,16 +117,14 @@ const command: Command = {
 			if (playerJson.first_login) firstLogin = `<t:${Math.round(new Date(playerJson.first_login).getTime() / 1000)}:F>`
 			else firstLogin = getString("firstLoginHidden")
 
-			const statsEmbed = new MessageEmbed()
-				.setColor(color)
-				.setAuthor(getString("moduleName"))
-				.setTitle(`${rank} ${username}`)
-				.setThumbnail(skinRender)
-				.setDescription(
-					`${getString("statsDesc", { username: username, link: `(https://api.slothpixel.me/api/players/${uuid})` })}\n${uuidDb ? `${getString("userVerified", { user: `<@!${uuidDb.id}>` })}\n` : ""
-					}${getString("updateNote")}\n${getString("otherStats")}`
-				)
-				.addFields(
+			const statsEmbed = new MessageEmbed({
+				color,
+				author: { name: getString("moduleName") },
+				title: `${rank} ${username}`,
+				thumbnail: { url: skinRender },
+				description: `${getString("statsDesc", { username: username, link: `(https://api.slothpixel.me/api/players/${uuid})` })}\n${uuidDb ? `${getString("userVerified", { user: `<@!${uuidDb.id}>` })}\n` : ""
+					}${getString("updateNote")}\n${getString("otherStats")}`,
+				fields: [
 					{ name: getString("networkLevel"), value: Math.abs(playerJson.level).toLocaleString(locale), inline: true },
 					{ name: getString("ap"), value: playerJson.achievement_points.toLocaleString(locale), inline: true },
 					{ name: getString("first_login"), value: firstLogin, inline: true },
@@ -134,8 +132,9 @@ const command: Command = {
 					{ name: getString("language"), value: getString(playerJson.language), inline: true },
 					{ name: online, value: last_seen, inline: true },
 					{ name: getString(playerJson.online ? "last_login" : "last_logout"), value: lastLogin, inline: true }
-				)
-				.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+				],
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true })}
+			})
 			return statsEmbed
 		}
 
@@ -191,24 +190,23 @@ const command: Command = {
 				if (!socialMedia.HYPIXEL.startsWith("https://")) forums = `[${getString("link")}](https://${socialMedia.HYPIXEL})`
 				else forums = `[${getString("link")}](${socialMedia.HYPIXEL})`
 			} else forums = getString("notConnected")
-			const socialEmbed = new MessageEmbed()
-				.setColor(color)
-				.setAuthor(getString("moduleName"))
-				.setTitle(`${rank} ${username}`)
-				.setThumbnail(skinRender)
-				.setDescription(
-					`${getString("socialMedia", { username: username, link: `(https://api.slothpixel.me/api/players/${uuid})` })}\n${uuidDb ? `${getString("userVerified", { user: `<@!${uuidDb.id}>` })}\n` : ""
-					}${getString("updateNote")}\n${getString("otherStats")}`
-				)
-				.addFields(
+			const socialEmbed = new MessageEmbed({
+				color,
+				author: { name: getString("moduleName") },
+				title: `${rank} ${username}`,
+				thumbnail: { url: skinRender },
+				description: `${getString("socialMedia", { username: username, link: `(https://api.slothpixel.me/api/players/${uuid})` })}\n${uuidDb ? `${getString("userVerified", { user: `<@!${uuidDb.id}>` })}\n` : ""
+					}${getString("updateNote")}\n${getString("otherStats")}`,
+				fields: [
 					{ name: "Twitter", value: twitter, inline: true },
 					{ name: "YouTube", value: youtube, inline: true },
 					{ name: "Instagram", value: instagram, inline: true },
 					{ name: "Twitch", value: twitch, inline: true },
 					{ name: "Discord", value: discord!, inline: true },
 					{ name: "Hypixel Forums", value: forums, inline: true }
-				)
-				.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+				],
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true })}
+			})
 			return socialEmbed
 		}
 
@@ -217,20 +215,24 @@ const command: Command = {
 
 			const color = parseColorCode(guildJson.tag_color)
 
-			const embed = new MessageEmbed()
-				.setColor(color === "#AAAAAA" ? "BLURPLE" : color)
-				.setAuthor(getString("moduleName"))
-				.setTitle(`${guildJson.name}${guildJson.tag ? ` [${guildJson.tag.replace(/&[a-f0-9k-or]/gi, "")}]` : ""}`)
-				.setThumbnail(skinRender)
-				.setDescription(
-					`${getString("guildDesc", {
-						player: playerJson.username,
-						guildName: guildJson.name,
-						link: `(https://api.slothpixel.me/api/guilds/${uuid})`
-					})}\n${getString("updateNote")}\n\n${guildJson.description ? `**${getString("guildDescHypixel")}**: ${guildJson.description}` : getString("noGuildDesc")}`
-				)
-				.addFields(
-					{ name: getString("guildLevel"), value: guildJson.level.toLocaleString(getString("region.dateLocale", "global")), inline: true },
+			const embed = new MessageEmbed({
+				color: color === "#AAAAAA" ? "BLURPLE" : color,
+				author: { name: getString("moduleName") },
+				title: `${guildJson.name}${guildJson.tag ? ` [${guildJson.tag.replace(/&[a-f0-9k-or]/gi, "")}]` : ""}`,
+				thumbnail: { url: skinRender },
+				description: `${getString("guildDesc", {
+					player: playerJson.username,
+					guildName: guildJson.name,
+					link: `(https://api.slothpixel.me/api/guilds/${uuid})`
+				})}\n${getString("updateNote")}\n\n${
+					guildJson.description ? `**${getString("guildDescHypixel")}**: ${guildJson.description}` : getString("noGuildDesc")
+				}`,
+				fields: [
+					{
+						name: getString("guildLevel"),
+						value: guildJson.level.toLocaleString(getString("region.dateLocale", "global")),
+						inline: true
+					},
 					{ name: getString("memberCount"), value: `${guildJson.members.length}/125`, inline: true },
 					{ name: getString("createdAt"), value: `<t:${Math.round(guildJson.created / 1000)}:F>`, inline: true },
 
@@ -245,16 +247,18 @@ const command: Command = {
 						value: guildJson.members.find(member => member.uuid === uuid)!.rank,
 						inline: true
 					}
-				)
-				.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+				],
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true })}
+			})
 
 			return embed
 		}
 
 		let embed = stats()
 
-		const optionsSelect = new MessageSelectMenu()
-			.addOptions(
+		const optionsSelect = new MessageSelectMenu({
+			customId: "statType",
+			options: [
 				{
 					label: getString("stats"),
 					value: "stats",
@@ -267,9 +271,9 @@ const command: Command = {
 					emoji: "twitter:821752918352068677",
 					default: false
 				}
-			)
-			.setCustomId("statType")
-		if (guildJson.guild) optionsSelect.addOptions( //guild is only present as null, so this means the user has a guild
+			]
+		})
+		if (guildJson.guild) optionsSelect.addOptions(
 			{
 				label: "Guild",
 				value: "guild",

--- a/src/commands/Utility/hypixelstats.ts
+++ b/src/commands/Utility/hypixelstats.ts
@@ -133,7 +133,7 @@ const command: Command = {
 					{ name: online, value: last_seen, inline: true },
 					{ name: getString(playerJson.online ? "last_login" : "last_logout"), value: lastLogin, inline: true }
 				],
-				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true })}
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
 			})
 			return statsEmbed
 		}
@@ -205,7 +205,7 @@ const command: Command = {
 					{ name: "Discord", value: discord!, inline: true },
 					{ name: "Hypixel Forums", value: forums, inline: true }
 				],
-				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true })}
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
 			})
 			return socialEmbed
 		}
@@ -224,9 +224,7 @@ const command: Command = {
 					player: playerJson.username,
 					guildName: guildJson.name,
 					link: `(https://api.slothpixel.me/api/guilds/${uuid})`
-				})}\n${getString("updateNote")}\n\n${
-					guildJson.description ? `**${getString("guildDescHypixel")}**: ${guildJson.description}` : getString("noGuildDesc")
-				}`,
+				})}\n${getString("updateNote")}\n\n${guildJson.description ? `**${getString("guildDescHypixel")}**: ${guildJson.description}` : getString("noGuildDesc")}`,
 				fields: [
 					{
 						name: getString("guildLevel"),
@@ -248,7 +246,7 @@ const command: Command = {
 						inline: true
 					}
 				],
-				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true })}
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
 			})
 
 			return embed

--- a/src/commands/Utility/hypixelunverify.ts
+++ b/src/commands/Utility/hypixelunverify.ts
@@ -27,19 +27,21 @@ const command: Command = {
 			await updateRoles(memberInput)
 			const result = await collection.updateOne({ id: memberInput.id }, { $unset: { uuid: true } })
 			if (result.modifiedCount) {
-				const embed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor("Hypixel Verification")
-					.setTitle(`Successfully unverified ${memberInput.user.tag}`)
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.success,
+					author: { name: "Hypixel Verification" },
+					title: `Successfully unverified ${memberInput.user.tag}`,
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.reply({ embeds: [embed] })
 			} else {
-				const embed = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor("Hypixel Verification")
-					.setTitle(`Couldn't unverify ${memberInput.user.tag}!`)
-					.setDescription("This happened because this user isn't verified yet.")
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.error,
+					author: { name: "Hypixel Verification" },
+					title: `Couldn't unverify ${memberInput.user.tag}!`,
+					description: "This happened because this user isn't verified yet.",
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.reply({ embeds: [embed], ephemeral: true })
 			}
 		} else {
@@ -47,19 +49,21 @@ const command: Command = {
 			client.cooldowns.get(this.name)!.delete(interaction.user.id)
 			const result = await collection.updateOne({ id: interaction.user.id }, { $unset: { uuid: true } })
 			if (result.modifiedCount) {
-				const embed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor(getString("moduleName"))
-					.setTitle(getString("unverified"))
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.success,
+					author: { name: getString("moduleName") },
+					title: getString("unverified"),
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.reply({ embeds: [embed] })
 			} else {
-				const embed = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor(getString("moduleName"))
-					.setTitle(getString("notUnverified"))
-					.setDescription(getString("whyNotUnverified"))
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const embed = new MessageEmbed({
+					color: colors.error,
+					author: { name: getString("moduleName") },
+					title: getString("notUnverified"),
+					description: getString("whyNotUnverified"),
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.reply({ embeds: [embed], ephemeral: true })
 			}
 		}

--- a/src/commands/Utility/hypixelverify.ts
+++ b/src/commands/Utility/hypixelverify.ts
@@ -54,51 +54,58 @@ const command: Command = {
 			const result = await collection.updateOne({ id: interaction.user.id }, { $set: { uuid: json.uuid } }),
 				role = await updateRoles(interaction.member, json)
 			if (result.modifiedCount) {
-				const successEmbed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor(getString("moduleName"))
-					.setTitle(getString("success", { player: json.username }))
-					.setDescription(getString("role", { role: role.toString() }))
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const successEmbed = new MessageEmbed({
+					color: colors.success,
+					author: { name: getString("moduleName") },
+					title: getString("success", { player: json.username }),
+					description: getString("role", { role: `${role}` }),
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.editReply({ embeds: [successEmbed] })
 			} else {
-				const notChanged = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor(getString("moduleName"))
-					.setTitle(getString("alreadyVerified"))
-					.setDescription(getString("nameChangeDisclaimer"))
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const notChanged = new MessageEmbed({
+					color: colors.error,
+					author: { name: getString("moduleName") },
+					title: getString("alreadyVerified"),
+					description: getString("nameChangeDisclaimer"),
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.editReply({ embeds: [notChanged] })
 			}
 		} else if (memberInput && interaction.member.roles.cache.has(ids.roles.admin)) {
 			const result = await collection.updateOne({ id: memberInput.id }, { $set: { uuid: json.uuid } }),
 				role = await updateRoles(memberInput, json)
 			if (result.modifiedCount) {
-				const successEmbed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor("Hypixel Verification")
-					.setTitle(`Successfully verified ${memberInput.user.tag} as ${json.username}`)
-					.setDescription(`They were given the ${role} role due to their rank on the server.`)
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
-				if (json.links?.DISCORD !== memberInput.user.tag)
-					successEmbed.setDescription("⚠ This player's Discord is different from their user tag! I hope you know what you're doing.")
+				const successEmbed = new MessageEmbed({
+					color: colors.success,
+					author: { name: "Hypixel Verification" },
+					title: `Successfully verified ${memberInput.user.tag} as ${json.username}`,
+					description: `They were given the ${role} role due to their rank on the server.${
+						json.links?.DISCORD !== memberInput.user.tag
+							? "\n\n⚠ This player's Discord is different from their user tag! I hope you know what you're doing."
+							: ""
+					}`,
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.editReply({ embeds: [successEmbed] })
 			} else {
-				const notChanged = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor("Hypixel Verification")
-					.setTitle("This user is already verified")
-					.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				const notChanged = new MessageEmbed({
+					color: colors.error,
+					author: { name: "Hypixel Verification" },
+					title: "This user is already verified",
+					footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				return await interaction.editReply({ embeds: [notChanged] })
 			}
 		} else {
-			const errorEmbed = new MessageEmbed()
-				.setColor(colors.error)
-				.setAuthor(getString("moduleName"))
-				.setTitle(getString("error"))
-				.setDescription(getString("tutorial", { tag: interaction.user.tag }))
-				.setImage("https://i.imgur.com/JSeAHdG.gif")
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const errorEmbed = new MessageEmbed({
+				color: colors.error,
+				author: { name: getString("moduleName") },
+				title: getString("error"),
+				description: getString("tutorial", { tag: interaction.user.tag }),
+				image: { url: "https://i.imgur.com/JSeAHdG.gif"},
+				footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+			})
 			await interaction.editReply({ embeds: [errorEmbed] })
 		}
 	},

--- a/src/commands/Utility/language.ts
+++ b/src/commands/Utility/language.ts
@@ -9,35 +9,41 @@ import type { Command, GetStringFunction } from "../../lib/imports"
 const command: Command = {
 	name: "language",
 	description: "Changes your language, shows your current one or a list of available languages.",
-	options: [{
-		type: "SUB_COMMAND",
-		name: "set",
-		description: "Sets your language to a new one. Leave empty to see your current language",
-		options: [{
-			type: "STRING",
-			name: "language",
-			description: "The new language you want to set",
-			required: false,
-			autocomplete: true
-		}]
-	},
-	{
-		type: "SUB_COMMAND",
-		name: "list",
-		description: "Gives you a list of all the available languages",
-	},
-	{
-		type: "SUB_COMMAND",
-		name: "stats",
-		description: "Gives you usage statistics for a given language. Admin only",
-		options: [{
-			type: "STRING",
-			name: "language",
-			description: "The language to get usage statistics for",
-			required: true,
-			autocomplete: true
-		}],
-	}],
+	options: [
+		{
+			type: "SUB_COMMAND",
+			name: "set",
+			description: "Sets your language to a new one. Leave empty to see your current language",
+			options: [
+				{
+					type: "STRING",
+					name: "language",
+					description: "The new language you want to set",
+					required: false,
+					autocomplete: true
+				}
+			]
+		},
+		{
+			type: "SUB_COMMAND",
+			name: "list",
+			description: "Gives you a list of all the available languages"
+		},
+		{
+			type: "SUB_COMMAND",
+			name: "stats",
+			description: "Gives you usage statistics for a given language. Admin only",
+			options: [
+				{
+					type: "STRING",
+					name: "language",
+					description: "The language to get usage statistics for",
+					required: true,
+					autocomplete: true
+				}
+			]
+		}
+	],
 	channelWhitelist: [ids.channels.bots, ids.channels.staffBots, ids.channels.botDev],
 	allowDM: true,
 	cooldown: 5,
@@ -59,77 +65,105 @@ const command: Command = {
 				else languageString = getString(element)
 				langList.push(getString("listElement", { code: element, language: languageString ?? "Unknown" }))
 				if (index === array.length - 1) {
-					const embed = new MessageEmbed()
-						.setColor(colors.neutral)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("listTitle"))
-						.setDescription(langList.join("\n"))
-						.setFooter(randomTip, (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						color: colors.neutral,
+						author: { name: getString("moduleName") },
+						title: getString("listTitle"),
+						description: langList.join("\n")
+					})
 					await interaction.reply({ embeds: [embed] })
 				}
 			})
 		} else if (subCommand === "stats") {
-			if (!member?.roles.cache.has(ids.roles.admin)) return await interaction.reply({ content: getString("errors.noAccess", "global"), ephemeral: true })
+			if (!member?.roles.cache.has(ids.roles.admin))
+				return await interaction.reply({ content: getString("errors.noAccess", "global"), ephemeral: true })
 			const files = readdirSync(stringsFolder)
 			if (!files.includes(language!)) throw "falseLang"
 			const langUsers = await collection.find({ lang: language! }).toArray(),
 				users: string[] = []
 			langUsers.forEach(u => users.push(`<@!${u.id}>`))
-			const embed = new MessageEmbed()
-				.setColor(colors.neutral)
-				.setAuthor("Language")
-				.setTitle(`There ${langUsers.length === 1 ? `is ${langUsers.length} user` : `are ${langUsers.length} users`} using that language at the moment.`)
-				.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: colors.neutral,
+				author: {
+					name: getString("Language")
+				},
+				title: `There ${
+					langUsers.length === 1 ? `is ${langUsers.length} user` : `are ${langUsers.length} users`
+				} using that language at the moment.`,
+				footer: {
+					text: randomTip,
+					iconURL: member.displayAvatarURL({ format: "png", dynamic: true })
+				}
+			})
+
 			if (language !== "en") embed.setDescription(users.join(", "))
 			await interaction.reply({ embeds: [embed] })
-		}
-		else if (subCommand === "set" && language) {
+		} else if (subCommand === "set" && language) {
 			if (language === "se") language = "sv"
 			const langdb = await db.collection<LangDbEntry>("langdb").find().toArray(),
 				langdbEntry = langdb.find(l => l.name.toLowerCase() === language)
 			if (langdbEntry) language = langdbEntry.code
 			if (language === "empty" && !member?.roles.cache.has(ids.roles.admin)) language = "denied"
-			access(`./strings/${language}/language.json`, constants.F_OK, async (err) => {
+			access(`./strings/${language}/language.json`, constants.F_OK, async err => {
 				if (!err) {
-					if (getString("changedToTitle", this.name, "en") !== getString("changedToTitle", this.name, language) || language === "en") {
+					if (
+						getString("changedToTitle", this.name, "en") !== getString("changedToTitle", this.name, language) ||
+						language === "en"
+					) {
 						const result = await collection.updateOne({ id: interaction.user.id }, { $set: { lang: language! } })
 						if (result.modifiedCount) {
 							randomTip = generateTip(getString, language)
-							const embed = new MessageEmbed()
-								.setColor(colors.success)
-								.setAuthor(getString("moduleName", this.name, language))
-								.setTitle(getString("changedToTitle", this.name, language))
-								.setDescription(getString("credits", this.name, language))
-								.setFooter(randomTip, (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+							const embed = new MessageEmbed({
+								color: colors.success,
+								author: { name: getString("moduleName", this.name, language) },
+								title: getString("changedToTitle", this.name, language),
+								description: getString("credits", this.name, language),
+								footer: {
+									text: randomTip,
+									iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+								}
+							})
 							return await interaction.reply({ embeds: [embed] })
 						} else {
-							const embed = new MessageEmbed()
-								.setColor(colors.error)
-								.setAuthor(getString("moduleName", this.name, language))
-								.setTitle(getString("didntChange", this.name, language))
-								.setDescription(getString("alreadyThis", this.name, language))
-								.setFooter(randomTip, (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+							const embed = new MessageEmbed({
+								color: colors.error,
+								author: { name: getString("moduleName", this.name, language) },
+								title: getString("didntChange", language),
+								description: getString("alreadyThis", this.name, language),
+								footer: {
+									text: randomTip,
+									iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+								}
+							})
 							return await interaction.reply({ embeds: [embed] })
 						}
 					} else {
-						const embed = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor(getString("moduleName"))
-							.setTitle(getString("didntChange"))
-							.setDescription(getString("notTranslated"))
-							.setFooter(randomTip, (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+						const embed = new MessageEmbed({
+							color: colors.error,
+							author: { name: getString("moduleName") },
+							title: getString("moduleName"),
+							description: getString("notTranslated"),
+							footer: {
+								text: randomTip,
+								iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+							}
+						})
 						return await interaction.reply({ embeds: [embed] })
 					}
 				} else {
 					readdir(stringsFolder, async (_err, files) => {
 						const emptyIndex = files.indexOf("empty")
 						if (emptyIndex > -1 && !member?.roles.cache.has(ids.roles.admin)) files.splice(emptyIndex, 1)
-						const embed = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor(getString("moduleName"))
-							.setTitle(getString("errorTitle"))
-							.setDescription(`${getString("errorDescription")}\n\`${files.join("`, `")}\`\n${getString("suggestAdd")}`)
-							.setFooter(randomTip, (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+						const embed = new MessageEmbed({
+							color: colors.error,
+							author: { name: getString("moduleName") },
+							title: getString("errorTitle"),
+							description: `${getString("errorDescription")}\n\`${files.join("`, `")}\`\n${getString("suggestAdd")}`,
+							footer: {
+								text: randomTip,
+								iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+							}
+						})
 						await interaction.reply({ embeds: [embed] })
 					})
 				}
@@ -138,12 +172,16 @@ const command: Command = {
 			const files = readdirSync(stringsFolder),
 				emptyIndex = files.indexOf("empty")
 			if (emptyIndex > -1 && !member?.roles.cache.has(ids.roles.admin)) files.splice(emptyIndex, 1)
-			const embed = new MessageEmbed()
-				.setColor(colors.neutral)
-				.setAuthor(getString("moduleName"))
-				.setTitle(getString("current"))
-				.setDescription(`${getString("errorDescription")}\n\`${files.join("`, `")}\`\n\n${getString("credits")}`)
-				.setFooter(randomTip, (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: colors.neutral,
+				author: { name: getString("moduleName") },
+				title: getString("current"),
+				description: `${getString("errorDescription")}\n\`${files.join("`, `")}\`\n\n${getString("credits")}`,
+				footer: {
+					text: randomTip,
+					iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+				}
+			})
 			await interaction.reply({ embeds: [embed] })
 		}
 	}

--- a/src/commands/Utility/language.ts
+++ b/src/commands/Utility/language.ts
@@ -84,16 +84,9 @@ const command: Command = {
 			langUsers.forEach(u => users.push(`<@!${u.id}>`))
 			const embed = new MessageEmbed({
 				color: colors.neutral,
-				author: {
-					name: getString("Language")
-				},
-				title: `There ${
-					langUsers.length === 1 ? `is ${langUsers.length} user` : `are ${langUsers.length} users`
-				} using that language at the moment.`,
-				footer: {
-					text: randomTip,
-					iconURL: member.displayAvatarURL({ format: "png", dynamic: true })
-				}
+				author: { name: "Language" },
+				title: `There ${langUsers.length === 1 ? `is ${langUsers.length} user` : `are ${langUsers.length} users`} using that language at the moment.`,
+				footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
 			})
 
 			if (language !== "en") embed.setDescription(users.join(", "))
@@ -118,10 +111,7 @@ const command: Command = {
 								author: { name: getString("moduleName", this.name, language) },
 								title: getString("changedToTitle", this.name, language),
 								description: getString("credits", this.name, language),
-								footer: {
-									text: randomTip,
-									iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-								}
+								footer: { text: randomTip, iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }) }
 							})
 							return await interaction.reply({ embeds: [embed] })
 						} else {
@@ -130,10 +120,7 @@ const command: Command = {
 								author: { name: getString("moduleName", this.name, language) },
 								title: getString("didntChange", language),
 								description: getString("alreadyThis", this.name, language),
-								footer: {
-									text: randomTip,
-									iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-								}
+								footer: { text: randomTip, iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }) }
 							})
 							return await interaction.reply({ embeds: [embed] })
 						}
@@ -141,12 +128,9 @@ const command: Command = {
 						const embed = new MessageEmbed({
 							color: colors.error,
 							author: { name: getString("moduleName") },
-							title: getString("moduleName"),
+							title: getString("didntChange"),
 							description: getString("notTranslated"),
-							footer: {
-								text: randomTip,
-								iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-							}
+							footer: { text: randomTip, iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }) }
 						})
 						return await interaction.reply({ embeds: [embed] })
 					}
@@ -159,10 +143,7 @@ const command: Command = {
 							author: { name: getString("moduleName") },
 							title: getString("errorTitle"),
 							description: `${getString("errorDescription")}\n\`${files.join("`, `")}\`\n${getString("suggestAdd")}`,
-							footer: {
-								text: randomTip,
-								iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-							}
+							footer: { text: randomTip, iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }) }
 						})
 						await interaction.reply({ embeds: [embed] })
 					})
@@ -177,10 +158,7 @@ const command: Command = {
 				author: { name: getString("moduleName") },
 				title: getString("current"),
 				description: `${getString("errorDescription")}\n\`${files.join("`, `")}\`\n\n${getString("credits")}`,
-				footer: {
-					text: randomTip,
-					iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-				}
+				footer: { text: randomTip, iconURL: (member ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }) }
 			})
 			await interaction.reply({ embeds: [embed] })
 		}

--- a/src/commands/Utility/languagestats.ts
+++ b/src/commands/Utility/languagestats.ts
@@ -46,19 +46,20 @@ const command: Command = {
 
 		const botData = await (crowdin.translationStatusApi.getProjectProgress(436418, 500)).then(res => res.data.find(language => language.data.languageId === lang.id)?.data ?? null)
 
-		let adapColour: number
+		let color: number
 		const approvalProgress = Math.max(hypixelData?.approvalProgress ?? 0, quickplayData?.approvalProgress ?? 0, sbaData?.approvalProgress ?? 0, botData?.approvalProgress ?? 0)
-		if (approvalProgress >= 90) adapColour = colors.success
-		else if (approvalProgress >= 50) adapColour = colors.loading
-		else adapColour = colors.error
+		if (approvalProgress >= 90) color = colors.success
+		else if (approvalProgress >= 50) color = colors.loading
+		else color = colors.error
 
-		const embed = new MessageEmbed()
-			.setColor(adapColour)
-			.setThumbnail(lang.flag)
-			.setAuthor(getString("moduleName"))
-			.setTitle(`${lang.emoji} | ${getString(`languages.${lang.code}`)}`)
-			.setDescription(`${getString("statsAll", { language: getString(`languages.${lang.code}`) })}`)
-			.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color,
+			thumbnail: { url: lang.flag },
+			author: { name: getString("moduleName") },
+			title: `${lang.emoji} | ${getString(`languages.${lang.code}`)}`,
+			description: `${getString("statsAll", { language: getString(`languages.${lang.code}`) })}`,
+			footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+		})
 		if (hypixelData)
 			embed.addField(
 				"Hypixel",

--- a/src/commands/Utility/minecraft.ts
+++ b/src/commands/Utility/minecraft.ts
@@ -1,5 +1,5 @@
 import axios from "axios"
-import { EmbedFieldData, GuildMember, Message, MessageActionRow, MessageButton, MessageEmbed } from "discord.js"
+import { GuildMember, Message, MessageActionRow, MessageButton, MessageEmbed } from "discord.js"
 import { client } from "../../index"
 import { colors, ids } from "../../config.json"
 import { db, DbUser } from "../../lib/dbclient"
@@ -83,29 +83,34 @@ const command: Command = {
 					const nameHistoryEmbed = fetchPage(0, pages)
 					await interaction.editReply({ embeds: [nameHistoryEmbed] })
 				} else {
-					let controlButtons = new MessageActionRow()
-						.addComponents(
-							new MessageButton()
-								.setStyle("SUCCESS")
-								.setEmoji("⏮️")
-								.setCustomId("first")
-								.setLabel(getString("pagination.first", "global")),
-							new MessageButton()
-								.setStyle("SUCCESS")
-								.setEmoji("◀️")
-								.setCustomId("previous")
-								.setLabel(getString("pagination.previous", "global")),
-							new MessageButton()
-								.setStyle("SUCCESS")
-								.setEmoji("▶️")
-								.setCustomId("next")
-								.setLabel(getString("pagination.next", "global")),
-							new MessageButton()
-								.setStyle("SUCCESS")
-								.setEmoji("⏭️")
-								.setCustomId("last")
-								.setLabel(getString("pagination.last", "global"))
-						),
+					let controlButtons = new MessageActionRow({
+						components: [
+							new MessageButton({
+								style: "SUCCESS",
+								customId: "first",
+								emoji: "⏮️",
+								label: getString("pagination.first", "global")
+							}),
+							new MessageButton({
+								style: "SUCCESS",
+								customId: "previous",
+								emoji: "◀️",
+								label: getString("pagination.previous", "global")
+							}),
+							new MessageButton({
+								style: "SUCCESS",
+								customId: "next",
+								emoji: "▶️",
+								label: getString("pagination.next", "global")
+							}),
+							new MessageButton({
+								style: "SUCCESS",
+								customId: "last",
+								emoji: "⏭️",
+								label: getString("pagination.last", "global")
+							})
+						]
+					}),
 						page = 0,
 						pageEmbed = fetchPage(page, pages)
 
@@ -140,49 +145,45 @@ const command: Command = {
 				}
 
 				function fetchPage(page: number, pages: NameHistory[][]) {
-					return new MessageEmbed()
-						.setColor(colors.success)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("history.nameHistoryFor", { username }))
-						.setDescription(
-							nameHistory.length - 1
-								? nameHistory.length - 1 == 1
-									? getString(isOwnUser ? "history.youChangedName1" : "history.userChangedName1", { username })
-									: getString(isOwnUser ? "history.youChangedName" : "history.userChangedName", { username, number: nameHistory.length - 1 })
-								: getString(isOwnUser ? "history.youNeverChanged" : "history.userNeverChanged", { username })
-						)
-						.addFields(constructFields(pages[page]))
-						.setFooter(
-							pages.length == 1
+					return new MessageEmbed({
+						color: colors.success,
+						author: { name: getString("moduleName") },
+						title: getString("history.nameHistoryFor", { username }),
+						description: nameHistory.length - 1
+							? nameHistory.length - 1 == 1
+								? getString(isOwnUser ? "history.youChangedName1" : "history.userChangedName1", { username })
+								: getString(isOwnUser ? "history.youChangedName" : "history.userChangedName", { username, number: nameHistory.length - 1 })
+							: getString(isOwnUser ? "history.youNeverChanged" : "history.userNeverChanged", { username }),
+						fields: constructFields(pages[page]),
+						footer: {
+							text: pages.length == 1
 								? randomTip
 								: getString("pagination.page", { number: page + 1, total: pages.length }, "global"),
-							member.displayAvatarURL({ format: "png", dynamic: true })
-						)
+							iconURL: member.displayAvatarURL({ format: "png", dynamic: true })
+						}
+					})
 				}
 
 				function constructFields(array: NameHistory[]) {
-					const fields: EmbedFieldData[] = []
-					array.forEach(name =>
-						fields.push({
-							name: name.name,
-							value: name.changedToAt ? `<t:${Math.round(new Date(name.changedToAt!).getTime() / 1000)}:F>` : getString("history.firstName"),
-							inline: true
-						})
-					)
-					return fields
+					return array.map(name => ({
+						name: name.name,
+						value: name.changedToAt ? `<t:${Math.round(new Date(name.changedToAt!).getTime() / 1000)}:F>` : getString("history.firstName"),
+						inline: true
+					}))
 				}
 
 				break
 			case "skin":
-				const skinEmbed = new MessageEmbed()
-					.setColor(colors.success)
-					.setAuthor(getString("moduleName"))
-					.setTitle(isOwnUser
+				const skinEmbed = new MessageEmbed({
+					color: colors.success,
+					author: { name: getString("moduleName") },
+					title: isOwnUser
 						? getString("skin.yourSkin")
-						: getString("skin.userSkin", { user: (await getPlayer(uuid)).name }))
-					.setDescription(uuidDb && !isOwnUser ? getString("skin.isLinked", { user: `<@!${uuidDb.id}>` }) : "")
-					.setImage(`https://crafatar.com/renders/body/${uuid}?overlay`)
-					.setFooter(randomTip, member.displayAvatarURL({ format: "png", dynamic: true }))
+						: getString("skin.userSkin", { user: (await getPlayer(uuid)).name }),
+					description: uuidDb && !isOwnUser ? getString("skin.isLinked", { user: `<@!${uuidDb.id}>` }) : "",
+					image: { url: `https://crafatar.com/renders/body/${uuid}?overlay` },
+					footer: { text: randomTip, iconURL: member.displayAvatarURL({ format: "png", dynamic: true }) }
+				})
 				await interaction.editReply({ embeds: [skinEmbed] })
 				break
 		}

--- a/src/commands/Utility/prefix.ts
+++ b/src/commands/Utility/prefix.ts
@@ -10,12 +10,14 @@ import type { Command, GetStringFunction } from "../../lib/imports"
 const command: Command = {
 	name: "prefix",
 	description: "Gives the author the appropriate prefix for their language(s).",
-	options: [{
-		type: "STRING",
-		name: "flags",
-		description: "The flags to be applied to your prefix.",
-		required: false
-	}],
+	options: [
+		{
+			type: "STRING",
+			name: "flags",
+			description: "The flags to be applied to your prefix.",
+			required: false
+		}
+	],
 	cooldown: 30,
 	roleWhitelist: [
 		ids.roles.botTranslator,
@@ -34,137 +36,229 @@ const command: Command = {
 			nickNoPrefix = interaction.member.displayName.replaceAll(/\[[^\s]*\] ?/g, "").trim(),
 			langdb = await db.collection<LangDbEntry>("langdb").find().toArray()
 
-		if (interaction.options.getString("flags", false) && !interaction.member.roles.cache.hasAny(ids.roles.hypixelTranslator, ids.roles.hypixelPf)) {
+		if (
+			interaction.options.getString("flags", false) &&
+			!interaction.member.roles.cache.hasAny(ids.roles.hypixelTranslator, ids.roles.hypixelPf)
+		) {
 			const flagEmojis: (string | null)[] = []
-			interaction.options.getString("flags", true).split(" ").forEach(emoji => {
-				if (emoji.toLowerCase() === "lol" || emoji.toLowerCase() === "lolcat") flagEmojis.push("😹")
-				else if (emoji.toLowerCase() === "enpt" || emoji.toLowerCase() === "pirate") flagEmojis.push("☠")
-				else if (emoji.toLowerCase() === "ib" || emoji.toLowerCase() === "banana") flagEmojis.push("🍌")
-				else if (emoji.toLowerCase() === "bc" || emoji.toLowerCase() === "biscuitish") flagEmojis.push("🍪")
-				else flagEmojis.push(getEmoji(emoji))
-			})
+			interaction.options
+				.getString("flags", true)
+				.split(" ")
+				.forEach(emoji => {
+					if (emoji.toLowerCase() === "lol" || emoji.toLowerCase() === "lolcat") flagEmojis.push("😹")
+					else if (emoji.toLowerCase() === "enpt" || emoji.toLowerCase() === "pirate") flagEmojis.push("☠")
+					else if (emoji.toLowerCase() === "ib" || emoji.toLowerCase() === "banana") flagEmojis.push("🍌")
+					else if (emoji.toLowerCase() === "bc" || emoji.toLowerCase() === "biscuitish") flagEmojis.push("🍪")
+					else flagEmojis.push(getEmoji(emoji))
+				})
 			if (!flagEmojis.length || flagEmojis.includes(null)) throw "falseFlag"
 
 			let prefix = flagEmojis.join("-")
-			const embed = new MessageEmbed()
-				.setColor(colors.neutral)
-				.setAuthor(getString("moduleName"))
-				.setTitle(getString("caution"))
-				.setDescription(`${getString("warning")}\n${getString("reactTimer", { cooldown: this.cooldown! })}`)
-				.addField(getString("previewT"), `\`[${prefix}] ${nickNoPrefix}\``)
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true })),
-				confirmButtons = new MessageActionRow()
-					.addComponents(
-						new MessageButton()
-							.setCustomId("confirm")
-							.setStyle("SUCCESS")
-							.setLabel(getString("pagination.confirm", "global"))
-							.setEmoji("✅"),
-						new MessageButton()
-							.setCustomId("cancel")
-							.setStyle("DANGER")
-							.setEmoji("❎")
-							.setLabel(getString("pagination.cancel", "global"))
-					)
+			const embed = new MessageEmbed({
+					author: { name: getString("moduleName") },
+					title: getString("caution"),
+					description: `${getString("warning")}\n${getString("reactTimer", { cooldown: this.cooldown! })}`,
+					fields: [
+						{
+							name: getString("previewT"),
+							value: `\`[${prefix}] ${nickNoPrefix}\``
+						}
+					],
+					footer: {
+						text: randomTip,
+						iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+					}
+				}),
+				confirmButtons = new MessageActionRow({
+					components: [
+						new MessageButton({
+							customId: "confirm",
+							style: "SUCCESS",
+							label: getString("pagination.confirm", "global"),
+							emoji: "✅"
+						}),
+						new MessageButton({
+							customId: "cancel",
+							style: "DANGER",
+							label: getString("pagination.cancel", "global"),
+							emoji: "❎"
+						})
+					]
+				})
 			const msg = await interaction.reply({ embeds: [embed], components: [confirmButtons], fetchReply: true }),
 				collector = msg.createMessageComponentCollector<"BUTTON">({ idle: this.cooldown! * 1000 })
 
 			confirmButtons.components.forEach(button => button.setDisabled(true))
 			collector.on("collect", async buttonInteraction => {
 				const userDb: DbUser = await client.getUser(buttonInteraction.user.id)
-				if (interaction.user.id !== buttonInteraction.user.id) return await buttonInteraction.reply({ content: getString("pagination.notYours", { command: `/${this.name}` }, "global", userDb.lang), ephemeral: true })
+				if (interaction.user.id !== buttonInteraction.user.id)
+					return await buttonInteraction.reply({
+						content: getString("pagination.notYours", { command: `/${this.name}` }, "global", userDb.lang),
+						ephemeral: true
+					})
 				collector.stop("responded")
 				if (buttonInteraction.customId === "confirm") {
-					if (interaction.member.nickname !== (`[${prefix}] ${nickNoPrefix}`)) {
-						await interaction.member.setNickname(`[${prefix}] ${nickNoPrefix}`, "Used the prefix command")
+					if (interaction.member.nickname !== `[${prefix}] ${nickNoPrefix}`) {
+						await interaction.member
+							.setNickname(`[${prefix}] ${nickNoPrefix}`, "Used the prefix command")
 							.then(async () => {
-								const embed = new MessageEmbed()
-									.setColor(colors.success)
-									.setAuthor(getString("moduleName"))
-									.setTitle(getString("saved"))
-									.addField(getString("newNickT"), `\`[${prefix}] ${nickNoPrefix}\``)
-									.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+								const embed = new MessageEmbed({
+									author: { name: getString("moduleName") },
+									title: getString("saved"),
+									fields: [
+										{
+											name: getString("newNickT"),
+											value: `\`[${prefix}] ${nickNoPrefix}\``
+										}
+									],
+									footer: {
+										text: randomTip,
+										iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+									}
+								})
 								await interaction.editReply({ embeds: [embed], components: [confirmButtons] })
-								const staffAlert = new MessageEmbed()
-									.setColor(colors.loading)
-									.setAuthor("Prefix")
-									.setTitle("A user manually changed their prefix")
-									.setDescription(`${interaction.user} manually changed their prefix to include the following flag: ${prefix}\nMake sure they have the appropriate roles for this prefix and, if not, follow the appropriate procedure`)
-									.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
-								await (interaction.client.channels.cache.get(ids.channels.staffBots) as TextChannel).send({ embeds: [staffAlert] })
+								const staffAlert = new MessageEmbed({
+									author: { name: "Prefix" },
+									title: "A user manually changed their prefix",
+									description: `${interaction.user} manually changed their prefix to include the following flag: ${prefix}\nMake sure they have the appropriate roles for this prefix and, if not, follow the appropriate procedure`,
+									footer: {
+										text: randomTip,
+										iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+									}
+								})
+								await (interaction.client.channels.cache.get(ids.channels.staffBots) as TextChannel).send({
+									embeds: [staffAlert]
+								})
 							})
 							.catch(async err => {
-								const embed = new MessageEmbed()
-									.setColor(colors.error)
-									.setAuthor(getString("moduleName"))
-									.setTitle(getString("errors.error"))
-									.setDescription(err.toString())
-									.addField(getString("previewT"), `\`[${prefix}] ${nickNoPrefix}\``)
-									.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+								const embed = new MessageEmbed({
+									author: { name: getString("moduleName") },
+									title: getString("errors.error"),
+									description: err.toString(),
+									fields: [
+										{
+											name: getString("previewT"),
+											value: `\`[${prefix}] ${nickNoPrefix}\``
+										}
+									],
+									footer: {
+										text: randomTip,
+										iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+									}
+								})
 								await interaction.editReply({ embeds: [embed], components: [confirmButtons] })
 								console.log(err.stack ?? err)
 							})
 					} else {
-						const embed = new MessageEmbed()
-							.setColor(colors.success)
-							.setAuthor(getString("moduleName"))
-							.setTitle(getString("errors.alreadyThis") + getString("errors.notSaved"))
-							.addField(getString("newNickT"), getString("noChanges"))
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+						const embed = new MessageEmbed({
+							author: { name: getString("moduleName") },
+							title: getString("errors.alreadyThis") + getString("errors.notSaved"),
+							fields: [
+								{
+									name: getString("newNickT"),
+									value: getString("noChanges")
+								}
+							],
+							footer: {
+								text: randomTip,
+								iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+							}
+						})
 						await interaction.editReply({ embeds: [embed], components: [confirmButtons] })
 					}
 				} else if (buttonInteraction.customId === "cancel") {
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("errors.cancelled") + getString("errors.notSaved"))
-						.addField(getString("newNickT"), getString("noChanges"))
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						author: { name: getString("moduleName") },
+						title: getString("errors.cancelled") + getString("errors.notSaved"),
+						fields: [
+							{
+								name: getString("newNickT"),
+								value: getString("noChanges")
+							}
+						],
+						footer: {
+							text: randomTip,
+							iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+						}
+					})
 					await interaction.editReply({ embeds: [embed], components: [confirmButtons] })
 				}
 			})
 			collector.on("end", async (_collected, reason) => {
 				if (reason === "responded") return
 				if (prefix) {
-					if (interaction.member.nickname !== (`[${prefix}] ${nickNoPrefix}`)) {
-						await interaction.member.setNickname(`[${prefix}] ${nickNoPrefix}`, "Used the prefix command")
+					if (interaction.member.nickname !== `[${prefix}] ${nickNoPrefix}`) {
+						await interaction.member
+							.setNickname(`[${prefix}] ${nickNoPrefix}`, "Used the prefix command")
 							.then(async () => {
-								const embed = new MessageEmbed()
-									.setColor(colors.success)
-									.setAuthor(getString("moduleName"))
-									.setTitle(getString("saved"))
-									.addField(getString("newNickT"), `\`[${prefix}] ${nickNoPrefix}\``)
-									.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+								const embed = new MessageEmbed({
+									author: { name: getString("moduleName") },
+									title: getString("saved"),
+									fields: [
+										{
+											name: getString("newNickT"),
+											value: `\`[${prefix}] ${nickNoPrefix}\``
+										}
+									],
+									footer: {
+										text: randomTip,
+										iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+									}
+								})
 								await interaction.editReply({ embeds: [embed], components: [confirmButtons] })
 							})
 							.catch(async err => {
-								const embed = new MessageEmbed()
-									.setColor(colors.error)
-									.setAuthor(getString("moduleName"))
-									.setTitle(getString("errors.error"))
-									.setDescription(err.toString())
-									.addField(getString("previewT"), `\`[${prefix}] ${nickNoPrefix}\``)
-									.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+								const embed = new MessageEmbed({
+									author: { name: getString("moduleName") },
+									title: getString("errors.error"),
+									description: err.toString(),
+									fields: [
+										{
+											name: getString("previewT"),
+											value: `\`[${prefix}] ${nickNoPrefix}\``
+										}
+									],
+									footer: {
+										text: randomTip,
+										iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+									}
+								})
 								await interaction.editReply({ embeds: [embed], components: [confirmButtons] })
 								console.log(err.stack || err)
 							})
 					} else {
-						const embed = new MessageEmbed()
-							.setColor(colors.success)
-							.setAuthor(getString("moduleName"))
-							.setTitle(getString("errors.alreadyThis") + getString("errors.notSaved"))
-							.addField(getString("newNickT"), getString("noChanges"))
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+						const embed = new MessageEmbed({
+							author: { name: getString("moduleName") },
+							title: getString("errors.alreadyThis") + getString("errors.notSaved"),
+							fields: [
+								{
+									name: getString("newNickT"),
+									value: getString("noChanges")
+								}
+							],
+							footer: {
+								text: randomTip,
+								iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+							}
+						})
 						await interaction.editReply({ embeds: [embed], components: [confirmButtons] })
 					}
 				} else {
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("errors.timedOut"))
-						.setDescription(getString("errors.timeOutCustom") + getString("errors.notSaved"))
-						.addField(getString("newNickT"), getString("noChanges"))
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						author: { name: getString("moduleName") },
+						title: getString("errors.timedOut"),
+						description: getString("errors.timeOutCustom") + getString("errors.notSaved"),
+						fields: [
+							{
+								name: getString("newNickT"),
+								value: getString("noChanges")
+							}
+						],
+						footer: {
+							text: randomTip,
+							iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+						}
+					})
 					await interaction.editReply({ embeds: [embed], components: [confirmButtons] })
 				}
 			})
@@ -185,128 +279,193 @@ const command: Command = {
 			userLangs = userLangs.reverse()
 			const prefixButtons: MessageButton[] = []
 			userLangs.forEach(entry => {
-				const button = new MessageButton()
-					.setStyle("SUCCESS")
-					.setCustomId(entry.code)
-					.setEmoji(entry.emoji)
+				const button = new MessageButton({
+					style: "SUCCESS",
+					customId: entry.code,
+					emoji: entry.emoji
+				})
 				prefixButtons.push(button)
 			})
 			const controlButtons: MessageButton[] = [
-				new MessageButton()
-					.setCustomId("confirm")
-					.setStyle("SUCCESS")
-					.setDisabled(true)
-					.setEmoji("✅")
-					.setLabel(getString("pagination.confirm", "global")),
-				new MessageButton()
-					.setCustomId("cancel")
-					.setStyle("DANGER")
-					.setEmoji("❎")
-					.setLabel(getString("pagination.cancel", "global"))
+				new MessageButton({
+					style: "SUCCESS",
+					customId: "confirm",
+					emoji: "✅",
+					label: getString("pagination.confirm", "global"),
+					disabled: true
+				}),
+				new MessageButton({
+					style: "DANGER",
+					customId: "cancel",
+					emoji: "❎",
+					label: getString("pagination.cancel", "global")
+				})
 			]
 			const components: MessageButton[][] = []
 			let p = 0
-			while (p < prefixButtons.length) components.push(prefixButtons.slice(p, p += 5))
+			while (p < prefixButtons.length) components.push(prefixButtons.slice(p, (p += 5)))
 			components.push(controlButtons)
-			const rows = components.map(c => ({ type: "ACTION_ROW", components: c }) as const)
+			const rows = components.map(c => ({ type: "ACTION_ROW", components: c } as const))
 
 			if (!userLangs.length) {
-				if (interaction.member.roles.cache.find(role => role.name.startsWith("Bot ") && role.id !== ids.roles.botUpdates) || interaction.member.roles.cache.find(role => role.name.startsWith("SkyblockAddons "))) {
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("errors.trNoRoles"))
-						.setDescription(getString("customPrefix"))
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+				if (
+					interaction.member.roles.cache.find(role => role.name.startsWith("Bot ") && role.id !== ids.roles.botUpdates) ||
+					interaction.member.roles.cache.find(role => role.name.startsWith("SkyblockAddons "))
+				) {
+					const embed = new MessageEmbed({
+						author: { name: getString("moduleName") },
+						title: getString("errors.trNoRoles"),
+						description: getString("customPrefix"),
+						footer: {
+							text: randomTip,
+							iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+						}
+					})
 					client.cooldowns.get(this.name)!.delete(interaction.user.id)
 					return await interaction.editReply({ embeds: [embed] })
 				} else {
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("errors.noLanguages"))
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						author: { name: getString("moduleName") },
+						title: getString("errors.noLanguages"),
+						footer: {
+							text: randomTip,
+							iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+						}
+					})
 					client.cooldowns.get(this.name)!.delete(interaction.user.id)
 					return await interaction.editReply({ embeds: [embed] })
 				}
 			}
-			const noChangesEmbed = new MessageEmbed()
-				.setColor(colors.neutral)
-				.setAuthor(getString("moduleName"))
-				.setTitle(getString("react"))
-				.setDescription(getString("reactTimer", { cooldown: this.cooldown! }))
-				.addField(getString("previewT"), getString("noChanges"))
-				.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+			const noChangesEmbed = new MessageEmbed({
+				author: { name: getString("moduleName") },
+				title: getString("react"),
+				description: getString("reactTimer", { cooldown: this.cooldown! }),
+				fields: [
+					{
+						name: getString("previewT"),
+						value: getString("noChanges")
+					}
+				],
+				footer: {
+					text: randomTip,
+					iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+				}
+			})
 			const msg = await interaction.editReply({ embeds: [noChangesEmbed], components: rows }),
 				collector = msg.createMessageComponentCollector<"BUTTON">({ idle: this.cooldown! * 1000 })
 
 			collector.on("collect", async buttonInteraction => {
 				const userDb: DbUser = await client.getUser(buttonInteraction.user.id)
-				if (interaction.user.id !== buttonInteraction.user.id) return await buttonInteraction.reply({ content: getString("pagination.notYours", { command: `/${this.name}` }, "global", userDb.lang), ephemeral: true })
-				if (buttonInteraction.customId !== "cancel") components.at(-1)!.find(b => b.customId === "confirm")!.setDisabled(false)
+				if (interaction.user.id !== buttonInteraction.user.id)
+					return await buttonInteraction.reply({
+						content: getString("pagination.notYours", { command: `/${this.name}` }, "global", userDb.lang),
+						ephemeral: true
+					})
+				if (buttonInteraction.customId !== "cancel")
+					components
+						.at(-1)!
+						.find(b => b.customId === "confirm")!
+						.setDisabled(false)
 				if (buttonInteraction.customId === "confirm") {
 					components.forEach(buttons => buttons.forEach(button => button.setDisabled(true)))
 					collector.stop("responded")
 					if (prefixes) {
-						if (interaction.member.nickname !== (`[${prefixes}] ${nickNoPrefix}`)) {
-							await interaction.member.setNickname(`[${prefixes}] ${nickNoPrefix}`, "Used the prefix command")
+						if (interaction.member.nickname !== `[${prefixes}] ${nickNoPrefix}`) {
+							await interaction.member
+								.setNickname(`[${prefixes}] ${nickNoPrefix}`, "Used the prefix command")
 								.then(async () => {
-									const embed = new MessageEmbed()
-										.setColor(colors.success)
-										.setAuthor(getString("moduleName"))
-										.setTitle(getString("saved"))
-										.addField(getString("newNickT"), `\`[${prefixes}] ${nickNoPrefix}\``)
-										.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+									const embed = new MessageEmbed({
+										author: { name: getString("moduleName") },
+										title: getString("saved"),
+										fields: [
+											{
+												name: getString("newNickT"),
+												value: `\`[${prefixes}] ${nickNoPrefix}\``
+											}
+										],
+										footer: {
+											text: randomTip,
+											iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+										}
+									})
 									await buttonInteraction.update({ embeds: [embed], components: rows })
 								})
 								.catch(async err => {
-									const embed = new MessageEmbed()
-										.setColor(colors.error)
-										.setAuthor(getString("moduleName"))
-										.setTitle(getString("errors.error"))
-										.setDescription(err.toString())
-										.addField(getString("previewT"), `\`[${prefixes}] ${nickNoPrefix}\``)
-										.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+									const embed = new MessageEmbed({
+										author: { name: getString("moduleName") },
+										title: getString("errors.error"),
+										description: err.toString(),
+										fields: [
+											{
+												name: getString("previewT"),
+												value: `\`[${prefixes}] ${nickNoPrefix}\``
+											}
+										],
+										footer: {
+											text: randomTip,
+											iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+										}
+									})
 									await buttonInteraction.update({ embeds: [embed], components: rows })
 									console.log(err.stack ?? err)
 								})
 						} else {
-							const embed = new MessageEmbed()
-								.setColor(colors.error)
-								.setAuthor(getString("moduleName"))
-								.setTitle(getString("errors.alreadyThis") + getString("errors.notSaved"))
-								.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+							const embed = new MessageEmbed({
+								author: { name: getString("moduleName") },
+								title: getString("errors.alreadyThis") + getString("errors.notSaved"),
+								footer: {
+									text: randomTip,
+									iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+								}
+							})
 							await buttonInteraction.update({ embeds: [embed], components: rows })
 						}
 					} else {
-						const embed = new MessageEmbed()
-							.setColor(colors.error)
-							.setAuthor(getString("moduleName"))
-							.setTitle(getString("errors.confirmedNoFlags") + getString("errors.notSaved"))
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+						const embed = new MessageEmbed({
+							author: { name: getString("moduleName") },
+							title: getString("errors.confirmedNoFlags") + getString("errors.notSaved"),
+							footer: {
+								text: randomTip,
+								iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+							}
+						})
 						await buttonInteraction.update({ embeds: [embed], components: rows })
 					}
 				} else if (buttonInteraction.customId === "cancel") {
 					components.forEach(buttons => buttons.forEach(button => button.setDisabled(true)))
 					collector.stop("responded")
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("errors.cancelled") + getString("errors.notSaved"))
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						color: colors.error,
+						author: { name: getString("moduleName") },
+						title: getString("errors.cancelled") + getString("errors.notSaved"),
+						footer: {
+							text: randomTip,
+							iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+						}
+					})
 					await buttonInteraction.update({ embeds: [embed], components: rows })
 				} else {
 					const clickedEntry = langdb.find(entry => entry.code === buttonInteraction.customId)!
 					if (prefixes) prefixes = `${prefixes}-${clickedEntry.emoji}`
 					else prefixes = `${clickedEntry.emoji}`
-					components.find(button => button.find(b => b.customId === buttonInteraction.customId)?.setDisabled(true).setStyle("SECONDARY"))
-					const embed = new MessageEmbed()
-						.setColor(colors.neutral)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("react"))
-						.setDescription(getString("reactTimer2", { cooldown: this.cooldown! }))
-						.addField(getString("previewT"), `\`[${prefixes}] ${nickNoPrefix}\``)
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					components.find(button =>
+						button
+							.find(b => b.customId === buttonInteraction.customId)
+							?.setDisabled(true)
+							.setStyle("SECONDARY")
+					)
+					const embed = new MessageEmbed({
+						author: { name: getString("moduleName") },
+						title: getString("react"),
+						description: getString("reactTimer2", { cooldown: this.cooldown! }),
+						fields: [
+							{
+								name: getString("previewT"),
+								value: `\`[${prefixes}] ${nickNoPrefix}\``
+							}
+						],
+						footer: { text: randomTip, iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true }) }
+					})
 					await buttonInteraction.update({ embeds: [embed], components: rows })
 				}
 			})
@@ -315,45 +474,76 @@ const command: Command = {
 				if (reason === "responded") return
 				components.forEach(buttons => buttons.forEach(button => button.setDisabled(true)))
 				if (prefixes.length > 0) {
-					if (interaction.member.nickname !== (`[${prefixes}] ${nickNoPrefix}`)) {
-						interaction.member.setNickname(`[${prefixes}] ${nickNoPrefix}`, "Used the prefix command")
+					if (interaction.member.nickname !== `[${prefixes}] ${nickNoPrefix}`) {
+						interaction.member
+							.setNickname(`[${prefixes}] ${nickNoPrefix}`, "Used the prefix command")
 							.then(async () => {
-								const embed = new MessageEmbed()
-									.setColor(colors.success)
-									.setAuthor(getString("moduleName"))
-									.setTitle(getString("saved"))
-									.addField(getString("newNickT"), `\`[${prefixes}] ${nickNoPrefix}\``)
-									.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+								const embed = new MessageEmbed({
+									author: { name: getString("moduleName") },
+									title: getString("saved"),
+									fields: [
+										{
+											name: getString("newNickT"),
+											value: `\`[${prefixes}] ${nickNoPrefix}\``
+										}
+									],
+									footer: {
+										text: randomTip,
+										iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+									}
+								})
 								await interaction.editReply({ embeds: [embed], components: rows })
 							})
 							.catch(async err => {
-								const embed = new MessageEmbed()
-									.setColor(colors.error)
-									.setAuthor(getString("moduleName"))
-									.setTitle(getString("errors.error"))
-									.setDescription(err.toString())
-									.addField(getString("previewT"), `\`[${prefixes}] ${nickNoPrefix}\``)
-									.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+								const embed = new MessageEmbed({
+									author: { name: getString("moduleName") },
+									title: getString("errors.error"),
+									description: err.toString(),
+									fields: [
+										{
+											name: getString("previewT"),
+											value: `\`[${prefixes}] ${nickNoPrefix}\``
+										}
+									]
+								})
 								await interaction.editReply({ embeds: [embed], components: rows })
 								console.log(err.stack ?? err)
 							})
 					} else {
-						const embed = new MessageEmbed()
-							.setColor(colors.success)
-							.setAuthor(getString("moduleName"))
-							.setTitle(getString("errors.alreadyThis") + getString("errors.notSaved"))
-							.addField(getString("newNickT"), getString("noChanges"))
-							.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+						const embed = new MessageEmbed({
+							author: { name: getString("moduleName") },
+							title: getString("errors.alreadyThis") + getString("errors.notSaved"),
+							fields: [
+								{
+									name: getString("newNickT"),
+									value: getString("noChanges")
+								}
+							],
+							footer: {
+								text: randomTip,
+								iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+							}
+						})
 						await interaction.editReply({ embeds: [embed], components: rows })
 					}
 				} else {
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor(getString("moduleName"))
-						.setTitle(getString("errors.timedOut"))
-						.setDescription(getString("errors.timeOut") + getString("errors.notSaved"))
-						.addField(getString("newNickT"), getString("noChanges"))
-						.setFooter(randomTip, interaction.member.displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						author: {
+							name: getString("moduleName")
+						},
+						title: getString("errors.timedOut"),
+						description: getString("errors.timeOut") + getString("errors.notSaved"),
+						fields: [
+							{
+								name: getString("newNickT"),
+								value: getString("noChanges")
+							}
+						],
+						footer: {
+							text: randomTip,
+							iconURL: interaction.member.displayAvatarURL({ format: "png", dynamic: true })
+						}
+					})
 					await interaction.editReply({ embeds: [embed], components: rows })
 				}
 			})

--- a/src/commands/Utility/quote.ts
+++ b/src/commands/Utility/quote.ts
@@ -9,101 +9,113 @@ import type { Command, GetStringFunction } from "../../lib/imports"
 const command: Command = {
 	name: "quote",
 	description: "Gets (or adds) a funny/weird/wise quote from the server.",
-	options: [{
-		type: "SUB_COMMAND",
-		name: "get",
-		description: "Get a random/specific quote",
-		options: [{
-			type: "INTEGER",
-			name: "index",
-			description: "The index of the quote you want to see",
-			required: false,
-			autocomplete: true
-		}]
-	},
-	{
-		type: "SUB_COMMAND",
-		name: "add",
-		description: "Adds a new quote. Staff only",
-		options: [{
-			type: "STRING",
-			name: "quote",
-			description: "The quote you want to add",
-			required: true
+	options: [
+		{
+			type: "SUB_COMMAND",
+			name: "get",
+			description: "Get a random/specific quote",
+			options: [
+				{
+					type: "INTEGER",
+					name: "index",
+					description: "The index of the quote you want to see",
+					required: false,
+					autocomplete: true
+				}
+			]
 		},
 		{
-			type: "USER",
-			name: "author",
-			description: "The author of this quote",
-			required: true
+			type: "SUB_COMMAND",
+			name: "add",
+			description: "Adds a new quote. Staff only",
+			options: [
+				{
+					type: "STRING",
+					name: "quote",
+					description: "The quote you want to add",
+					required: true
+				},
+				{
+					type: "USER",
+					name: "author",
+					description: "The author of this quote",
+					required: true
+				},
+				{
+					type: "STRING",
+					name: "url",
+					description: "The url of the message this quote came from. If the message has an image it will be included as well",
+					required: false
+				},
+				{
+					type: "STRING",
+					name: "image",
+					description: "The url of the image to be included with this quote. Has priority over url's image if provided",
+					required: false
+				}
+			]
 		},
 		{
-			type: "STRING",
-			name: "url",
-			description: "The url of the message this quote came from. If the message has an image it will be included as well",
-			required: false
+			type: "SUB_COMMAND",
+			name: "edit",
+			description: "Edits a quote. Staff only",
+			options: [
+				{
+					type: "INTEGER",
+					name: "index",
+					description: "The index of the quote to edit",
+					required: true,
+					autocomplete: true
+				},
+				{
+					type: "STRING",
+					name: "quote",
+					description: "The new quote",
+					required: true
+				}
+			]
 		},
 		{
-			type: "STRING",
-			name: "image",
-			description: "The url of the image to be included with this quote. Has priority over url's image if provided",
-			required: false
-		}]
-	},
-	{
-		type: "SUB_COMMAND",
-		name: "edit",
-		description: "Edits a quote. Staff only",
-		options: [{
-			type: "INTEGER",
-			name: "index",
-			description: "The index of the quote to edit",
-			required: true,
-			autocomplete: true
+			type: "SUB_COMMAND",
+			name: "delete",
+			description: "Deletes a quote. Staff only",
+			options: [
+				{
+					type: "INTEGER",
+					name: "index",
+					description: "The index of the quote to delete",
+					required: true,
+					autocomplete: true
+				}
+			]
 		},
 		{
-			type: "STRING",
-			name: "quote",
-			description: "The new quote",
-			required: true
-		}]
-	},
-	{
-		type: "SUB_COMMAND",
-		name: "delete",
-		description: "Deletes a quote. Staff only",
-		options: [{
-			type: "INTEGER",
-			name: "index",
-			description: "The index of the quote to delete",
-			required: true,
-			autocomplete: true
-		}]
-	},
-	{
-		type: "SUB_COMMAND",
-		name: "link",
-		description: "Links a quote to a message. Staff only",
-		options: [{
-			type: "INTEGER",
-			name: "index",
-			description: "The index of the quote to link",
-			required: true,
-			autocomplete: true
-		},
-		{
-			type: "STRING",
-			name: "url",
-			description: "The URL of the message to link this quote to",
-			required: true
-		},
-		{
-			type: "BOOLEAN",
-			name: "image",
-			description: "Whether or not to attach this message's image to the quote.",
-			required: false
-		}]
-	}],
+			type: "SUB_COMMAND",
+			name: "link",
+			description: "Links a quote to a message. Staff only",
+			options: [
+				{
+					type: "INTEGER",
+					name: "index",
+					description: "The index of the quote to link",
+					required: true,
+					autocomplete: true
+				},
+				{
+					type: "STRING",
+					name: "url",
+					description: "The URL of the message to link this quote to",
+					required: true
+				},
+				{
+					type: "BOOLEAN",
+					name: "image",
+					description: "Whether or not to attach this message's image to the quote.",
+					required: false
+				}
+			]
+		}
+	],
 	cooldown: 5,
 	allowDM: true,
 	channelWhitelist: [ids.channels.bots, ids.channels.staffBots, ids.channels.botDev],
@@ -123,7 +135,6 @@ const command: Command = {
 }
 
 async function findQuote(randomTip: string, interaction: CommandInteraction, getString: GetStringFunction, collection: Collection<Quote>) {
-
 	const count = await collection.estimatedDocumentCount()
 
 	let quoteId = interaction.options.getInteger("index", false)
@@ -131,29 +142,40 @@ async function findQuote(randomTip: string, interaction: CommandInteraction, get
 
 	const quote = await collection.findOne({ id: quoteId })
 	if (!quote) {
-		const embed = new MessageEmbed()
-			.setColor(colors.error)
-			.setAuthor(getString("moduleName"))
-			.setTitle(getString("invalidArg"))
-			.setDescription(getString("indexArg", { arg: quoteId!, max: count }))
-			.setFooter(randomTip, ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.error,
+			author: { name: getString("moduleName") },
+			title: getString("invalidArg"),
+			description: getString("indexArg", { arg: quoteId!, max: count }),
+			footer: {
+				text: randomTip,
+				iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+			}
+		})
 		return await interaction.reply({ embeds: [embed], ephemeral: true })
 	}
 	console.log(`Quote with ID ${quoteId} was requested`)
-	const author = await Promise.all(quote.author.map(async a => interaction.guild!.members.cache.get(a)?.toString() ?? (await interaction.client.users.fetch(a)).tag)),
-		embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor(getString("moduleName"))
-			.setTitle(quote.quote)
-			.setDescription(`      - ${author.join(" and ")}`)
-			.setFooter(randomTip, ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+	const author = await Promise.all(
+		quote.author.map(
+			async a => interaction.guild!.members.cache.get(a)?.toString() ?? (await interaction.client.users.fetch(a)).tag
+		)
+	),
+		embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: getString("moduleName") },
+			title: quote.quote,
+			description: `      - ${author.join(" and ")}`,
+			footer: {
+				text: randomTip,
+				iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
+			}
+		})
 	if (quote.imageURL) embed.setImage(quote.imageURL)
 	if (quote.url) embed.addField(getString("msgUrl"), quote.url)
 	return await interaction.reply({ embeds: [embed] })
 }
 
 async function addQuote(interaction: CommandInteraction, collection: Collection<Quote>) {
-
 	const quoteId = (await collection.estimatedDocumentCount()) + 1,
 		quote = interaction.options.getString("quote", true),
 		author = interaction.options.getUser("author", true),
@@ -164,20 +186,31 @@ async function addQuote(interaction: CommandInteraction, collection: Collection<
 
 	if (urlSplit) {
 		if (urlSplit.length === 7) {
-			(interaction.client.channels.cache.get(urlSplit[5]) as TextChannel | undefined)?.messages.fetch(urlSplit[6])
+			; (interaction.client.channels.cache.get(urlSplit[5]) as TextChannel | undefined)?.messages
+				.fetch(urlSplit[6])
 				.then(async msg => {
 					if (msg.attachments.size > 0) pictureUrl ??= msg.attachments.first()!.url
-					const embed = new MessageEmbed()
-						.setColor(colors.success)
-						.setAuthor("Quote")
-						.setTitle("Success! The following quote has been added:")
-						.setDescription(quote)
-						.addFields(
-							{ name: "User", value: `${author}` },
+					const embed = new MessageEmbed({
+						color: colors.success,
+						author: { name: "Quote" },
+						title: "Success! The following quote has been added:",
+						description: quote,
+						fields: [
+							{
+								name: "User",
+								value: `${author}`
+							},
 							{ name: "Quote number", value: `${quoteId}` },
 							{ name: "URL", value: url! }
-						)
-						.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+						],
+						footer: {
+							text: generateTip(),
+							iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+								format: "png",
+								dynamic: true
+							})
+						}
+					})
 					if (pictureUrl) {
 						embed.setImage(pictureUrl)
 						await collection.insertOne({ id: quoteId, quote: quote, author: [author.id], url: url!, imageURL: pictureUrl })
@@ -185,30 +218,55 @@ async function addQuote(interaction: CommandInteraction, collection: Collection<
 					await interaction.reply({ embeds: [embed] })
 				})
 				.catch(async () => {
-					const embed = new MessageEmbed()
-						.setColor(colors.error)
-						.setAuthor("Quote")
-						.setTitle("Couldn't find a message linked to that URL!")
-						.setDescription("Make sure you obtained it by coping the message URL directly and that I have permission to see that message.")
-						.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+					const embed = new MessageEmbed({
+						color: colors.error,
+						author: { name: "Quote" },
+						title: "Couldn't find a message linked to that URL!",
+						description:
+							"Make sure you obtained it by coping the message URL directly and that I have permission to see that message.",
+						footer: {
+							text: generateTip(),
+							iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+								format: "png",
+								dynamic: true
+							})
+						}
+					})
 					await interaction.reply({ embeds: [embed], ephemeral: true })
 				})
 		} else {
-			const embed = new MessageEmbed()
-				.setColor(colors.error)
-				.setAuthor("Quote")
-				.setTitle("Provided URL isn't a valid message URL!")
-				.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: colors.error,
+				author: { name: "Quote" },
+				title: "Provided URL isn't a valid message URL!",
+				footer: {
+					text: generateTip(),
+					iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+						format: "png",
+						dynamic: true
+					})
+				}
+			})
 			return await interaction.reply({ embeds: [embed], ephemeral: true })
 		}
 	} else {
-		const embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor("Quote")
-			.setTitle("Success! The following quote has been added:")
-			.setDescription(quote)
-			.addFields({ name: "User", value: `${author}` }, { name: "Quote number", value: `${quoteId}` })
-			.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: "Quote" },
+			title: "Success! The following quote has been added:",
+			description: quote,
+			fields: [
+				{ name: "User", value: `${author}` },
+				{ name: "Quote number", value: `${quoteId}` }
+			],
+			footer: {
+				text: generateTip(),
+				iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+					format: "png",
+					dynamic: true
+				})
+			}
+		})
 		if (pictureUrl) {
 			embed.setImage(pictureUrl)
 			await collection.insertOne({ id: quoteId, quote: quote, author: [author.id], imageURL: pictureUrl })
@@ -218,62 +276,88 @@ async function addQuote(interaction: CommandInteraction, collection: Collection<
 }
 
 async function editQuote(interaction: CommandInteraction, collection: Collection<Quote>) {
-
 	const quoteId = interaction.options.getInteger("index", true),
 		newQuote = interaction.options.getString("quote", true)
 	if (!quoteId) throw "noQuote"
 	const result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { quote: newQuote } })
 	if (result.value) {
 		const author = await Promise.all(result.value.author.map(async a => await interaction.client.users.fetch(a))),
-			embed = new MessageEmbed()
-				.setColor(colors.success)
-				.setAuthor("Quote")
-				.setTitle(`Successfully edited quote #${quoteId}`)
-				.addFields(
+			embed = new MessageEmbed({
+				color: colors.success,
+				author: { name: "Quote" },
+				title: `Successfully edited quote #${quoteId}`,
+				fields: [
 					{ name: "Old quote", value: result.value.quote },
 					{ name: "New quote", value: newQuote },
 					{ name: "Author", value: author.join(" and ") },
 					{ name: "Link", value: result.value.url ?? "None" }
-				)
-				.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+				],
+				footer: {
+					text: generateTip(),
+					iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+						format: "png",
+						dynamic: true
+					})
+				}
+			})
 		if (result.value.imageURL) embed.setImage(result.value.imageURL)
 		await interaction.reply({ embeds: [embed] })
 	} else {
-		const embed = new MessageEmbed()
-			.setColor(colors.error)
-			.setAuthor("Quote")
-			.setTitle("Couldn't find a quote with that ID!")
-			.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.error,
+			author: { name: "Quote" },
+			title: "Couldn't find a quote with that ID!",
+			footer: {
+				text: generateTip(),
+				iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+					format: "png",
+					dynamic: true
+				})
+			}
+		})
 		await interaction.reply({ embeds: [embed], ephemeral: true })
 	}
 }
 
 async function deleteQuote(interaction: CommandInteraction, collection: Collection<Quote>) {
-
 	const quoteId = interaction.options.getInteger("index", true)
 	if (quoteId <= 0) throw "noQuote"
 	const result = await collection.findOneAndDelete({ id: quoteId })
 	if (result.value) {
 		const author = await Promise.all(result.value.author.map(async a => await interaction.client.users.fetch(a)))
 		await collection.updateMany({ id: { $gt: quoteId } }, { $inc: { id: -1 } })
-		const embed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor("Quote")
-			.setTitle(`Successfully deleted quote #${quoteId}`)
-			.addFields(
+		const embed = new MessageEmbed({
+			color: colors.success,
+			author: { name: "Quote" },
+			title: `Successfully deleted quote #${quoteId}`,
+			fields: [
 				{ name: "Author", value: author.join(" and ") },
 				{ name: "Quote", value: result.value.quote },
 				{ name: "Link", value: result.value.url ?? "None" }
-			)
-			.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+			],
+			footer: {
+				text: generateTip(),
+				iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+					format: "png",
+					dynamic: true
+				})
+			}
+		})
 		if (result.value.imageURL) embed.setImage(result.value.imageURL)
 		await interaction.reply({ embeds: [embed] })
 	} else {
-		const embed = new MessageEmbed()
-			.setColor(colors.error)
-			.setAuthor("Quote")
-			.setTitle("Couldn't find a quote with that ID!")
-			.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+		const embed = new MessageEmbed({
+			color: colors.error,
+			author: { name: "Quote" },
+			title: "Couldn't find a quote with that ID!",
+			footer: {
+				text: generateTip(),
+				iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+					format: "png",
+					dynamic: true
+				})
+			}
+		})
 		await interaction.reply({ embeds: [embed], ephemeral: true })
 	}
 }
@@ -286,46 +370,63 @@ async function linkQuote(interaction: CommandInteraction, collection: Collection
 		.then(async msg => {
 			const firstAttachment = msg.attachments.first()?.url
 			let result
-			if (linkAttch && firstAttachment) result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url, imageURL: firstAttachment } })
+			if (linkAttch && firstAttachment)
+				result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url, imageURL: firstAttachment } })
 			else result = await collection.findOneAndUpdate({ id: quoteId }, { $set: { url: msg.url } })
 			if (result.value) {
 				const author = await Promise.all(result.value.author.map(a => interaction.client.users.fetch(a))),
-					embed = new MessageEmbed()
-						.setColor(colors.success)
-						.setAuthor("Quote")
-						.setTitle(`Successfully linked quote #${quoteId}`)
-						.addFields(
+					embed = new MessageEmbed({
+						color: colors.success,
+						author: { name: "Quote" },
+						title: `Successfully linked quote #${quoteId}`,
+						fields: [
 							{ name: "Old URL", value: result.value.url ?? "None" },
 							{ name: "New URL", value: msg.url },
 							{ name: "Quote", value: result.value.quote },
 							{ name: "Author", value: author.join(" and ") }
-						)
-						.setFooter(
-							generateTip(),
-							((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-						)
+						],
+						footer: {
+							text: generateTip(),
+							iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+								format: "png",
+								dynamic: true
+							})
+						}
+					}
+					)
 				if (linkAttch && firstAttachment) embed.setImage(firstAttachment)
 				else if (result.value.imageURL) embed.setImage(result.value.imageURL)
 				await interaction.reply({ embeds: [embed] })
 			} else {
-				const embed = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor("Quote")
-					.setTitle("Couldn't find a quote with that ID!")
-					.setFooter(
-						generateTip(),
-						((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true })
-					)
+				const embed = new MessageEmbed({
+					color: colors.error,
+					author: { name: "Quote"},
+					title: "Couldn't find a quote with that ID!",
+					footer: {
+						text: generateTip(),
+						iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+							format: "png",
+							dynamic: true
+						})
+					}
+				})
 				await interaction.reply({ embeds: [embed], ephemeral: true })
 			}
 		})
 		.catch(async () => {
-			const embed = new MessageEmbed()
-				.setColor(colors.error)
-				.setAuthor("Quote")
-				.setTitle("Couldn't find a message linked to that URL!")
-				.setDescription("Make sure you obtained it by coping the message URL directly and that I have permission to see that message.")
-				.setFooter(generateTip(), ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({ format: "png", dynamic: true }))
+			const embed = new MessageEmbed({
+				color: colors.error,
+				author: { name: "Quote" },
+				title: "Couldn't find a quote with that ID!",
+				description: "Make sure you obtained it by coping the message URL directly and that I have permission to see that message.",
+				footer: {
+					text: generateTip(),
+					iconURL: ((interaction.member as GuildMember | null) ?? interaction.user).displayAvatarURL({
+						format: "png",
+						dynamic: true
+					})
+				}
+			})
 			await interaction.reply({ embeds: [embed], ephemeral: true })
 		})
 }

--- a/src/commands/Utility/verify.ts
+++ b/src/commands/Utility/verify.ts
@@ -60,12 +60,13 @@ const command: Command = {
 			} else {
 				await interaction.member.roles.remove(ids.roles.verified, "Unverified")
 				await collection.updateOne({ id: interaction.member.id }, { $set: { unverifiedTimestamp: Date.now() } })
-				const embed = new MessageEmbed()
-					.setColor(colors.error)
-					.setAuthor("Manual verification")
-					.setTitle("You were successfully unverified!")
-					.setDescription(`Since we didn't have your profile registered on our database, we'd like to ask you to kindly send it to us on the ${verify} channel. Please make sure your profile is public and that you have your Discord tag (${interaction.user.tag}) in your "About me" section.`)
-					.setFooter("Any messages you send here will be sent to staff upon confirmation.")
+				const embed = new MessageEmbed({
+					color: colors.error,
+					author: { name: "Manual verification" },
+					title: "You were successfully unverified!",
+					description: `Since we didn't have your profile registered on our database, we'd like to ask you to kindly send it to us on the ${verify} channel. Please make sure your profile is public and that you have your Discord tag (${interaction.user.tag}) in your "About me" section.`,
+					footer: { text: "Any messages you send here will be sent to staff upon confirmation." }
+				})
 				await interaction.user.send({ embeds: [embed] })
 					.then(async () => {
 						await verifyLogs.send(`${interaction.user} tried to verify with an invalid profile URL ${url ? `(<${url}>) ` : ""}or there was no profile stored for them.`)
@@ -74,12 +75,12 @@ const command: Command = {
 					.catch(async () => {
 						embed
 							.setDescription(`Since we didn't have your profile registered on our database, we'd like to ask you to kindly send it to us here. Please make sure your profile is public and that you have your Discord tag (${interaction.user.tag}) in your "About me" section.`)
-							.setFooter("")
+							.setFooter({ text: "" })
 						await verifyLogs.send(`${interaction.user} tried to verify with an invalid profile URL ${url ? `(<${url}>) ` : ""}or there was no profile stored for them but they had DMs off so I couldn't tell them.`)
 						const msg = await verify.send({ content: `${interaction.user} you had DMs disabled, so here's our message:`, embeds: [embed] })
 						await interaction.editReply({ content: `Your request has been processed, check ${verify} for more info!` })
 						await setTimeout(30_000)
-						if (!msg.deleted) await msg.delete()
+						await msg.delete().catch(() => null)
 					})
 				client.cooldowns.get(this.name)!.delete(interaction.user.id)
 			}

--- a/src/lib/crowdinverify.ts
+++ b/src/lib/crowdinverify.ts
@@ -29,10 +29,11 @@ const projectIDs: {
 async function crowdinVerify(member: GuildMember, url?: string | null, sendDms = false, sendLogs = true) {
 	const verifyLogs = member.client.channels.cache.get(ids.channels.verifyLogs) as TextChannel,
 		verify = member.client.channels.cache.get(ids.channels.verify) as TextChannel,
-		errorEmbed = new MessageEmbed()
-			.setColor(colors.error)
-			.setAuthor("Received message from staff")
-			.setFooter("Any messages you send here will be sent to staff upon confirmation."),
+		errorEmbed = new MessageEmbed({
+			color: colors.error,
+			author: { name: "Received message from staff" },
+			footer: { text: "Any messages you send here will be sent to staff upon confirmation." }
+		}),
 		langDb = db.collection<LangDbEntry>("langdb"),
 		usersColl = db.collection<DbUser>("users"),
 		statsColl = db.collection<Stats>("stats"),
@@ -51,10 +52,10 @@ async function crowdinVerify(member: GuildMember, url?: string | null, sendDms =
 			if (sendDms) member.send({ embeds: [errorEmbed] })
 				.then(async () => await verifyLogs.send(`${member} didn't send a valid profile URL. Let's hope they work their way around with the message I just sent them.`))
 				.catch(async () => {
-					errorEmbed.setFooter("This message will be deleted in a minute")
+					errorEmbed.setFooter({ text: "This message will be deleted in a minute" })
 					const msg = await verify.send({ content: `${member} you had DMs disabled, so here's our message,`, embeds: [errorEmbed] })
 					await setTimeout(60_000)
-					if (!msg.deleted) await msg.delete()
+					await msg.delete().catch(() => null)
 					await verifyLogs.send(`${member} didn't send a valid profile URL. Let's hope they work their way around with the message I just sent in <#${ids.channels.verify}> since they had DMs off.`)
 				})
 			else await verifyLogs.send(`The profile stored/provided for ${member} was invalid. Please fix this or ask them to fix this.`)
@@ -92,10 +93,10 @@ async function crowdinVerify(member: GuildMember, url?: string | null, sendDms =
 			if (sendDms) await member.send({ embeds: [errorEmbed] })
 				.then(async () => await verifyLogs.send(`${member} sent the wrong profile link (<${url}>). Let's hope they work their way around with the message I just sent them.`))
 				.catch(async () => {
-					errorEmbed.setFooter("This message will be deleted in a minute")
+					errorEmbed.setFooter({ text: "This message will be deleted in a minute" })
 					const msg = await verify.send({ content: `${member} you had DMs disabled, so here's our message,`, embeds: [errorEmbed] })
 					await setTimeout(60_000)
-					if (!msg.deleted) await msg.delete()
+					await msg.delete().catch(() => null)
 					await verifyLogs.send(`${member} sent the wrong profile link (<${url}>). Let's hope they work their way around with the message I just sent in <#${ids.channels.verify}> since they had DMs off.`)
 				})
 			else if (sendLogs) await verifyLogs.send(`The profile stored/provided for ${member} was invalid (<${url}>). Please fix this or ask them to fix this.`)
@@ -113,30 +114,34 @@ async function crowdinVerify(member: GuildMember, url?: string | null, sendDms =
 			if (sendDms) await member.send({ embeds: [errorEmbed] })
 				.then(async () => await verifyLogs.send(`${member}'s profile (<${url}>) was private, I let them know about that.`))
 				.catch(async () => {
-					errorEmbed.setFooter("This message will be deleted in a minute")
+					errorEmbed.setFooter({ text: "This message will be deleted in a minute" })
 					const msg = await verify.send({ content: `${member} you had DMs disabled, so here's our message,`, embeds: [errorEmbed] })
 					await setTimeout(60_000)
-					if (!msg.deleted) await msg.delete()
+					await msg.delete().catch(() => null)
 					await verifyLogs.send(`${member}'s profile was private (<${url}>), I let them know about that in <#${ids.channels.verify}> since they had DMs off.`)
 				})
 			else await verifyLogs.send(`${member}'s profile is private (<${url}>). Please ask them to change this.`)
 			await statsColl.insertOne({ type: "VERIFY", name: verifyType, user: member.id, error: true, errorMessage: "privateProfile" })
 			//#endregion
 		} else {
-			const dmEmbed = new MessageEmbed()
-				.setColor("BLURPLE")
-				.setAuthor("Received message from staff")
-				.setDescription("Hey there!\nYou have successfully verified your Crowdin account!\nSadly you didn't receive any roles because you don't translate for any of the projects we currently support.\nWhen you have started translating you can refresh your roles by running `/verify`\nIf you wanna know more about all the projects we currently support, run `/projects` here.")
-				.setFooter("Any messages you send here will be sent to staff upon confirmation."),
-				logEmbed = new MessageEmbed()
-					.setColor("BLURPLE")
-					.setTitle(`${member.user.tag} is now verified!`)
-					.setDescription(`${member} has not received any roles. They do not translate for any of the projects.`)
-					.addField("Profile", url)
+			const dmEmbed = new MessageEmbed({
+				color: "BLURPLE",
+				author: { name: "Received message from staff" },
+				description: "Hey there!\nYou have successfully verified your Crowdin account!\nSadly you didn't receive any roles because you don't translate for any of the projects we currently support.\nWhen you have started translating you can refresh your roles by running `/verify`\nIf you wanna know more about all the projects we currently support, run `/projects` here.",
+				footer: { text: "Any messages you send here will be sent to staff upon confirmation." }
+			}),
+				logEmbed = new MessageEmbed({
+					color: "BLURPLE",
+					title: `${member.user.tag} is now verified!`,
+					description: `${member} has not received any roles. They do not translate for any of the projects.`,
+					fields: [
+						{ name: "Profile", value: url }
+					]
+				})
 			if (sendDms) await member.send({ embeds: [dmEmbed] })
 				.then(async () => await verifyLogs.send({ embeds: [logEmbed] }))
 				.catch(async () => {
-					logEmbed.setFooter("Message not sent because user had DMs off")
+					logEmbed.setFooter({ text: "Message not sent because user had DMs off" })
 					await verifyLogs.send({ embeds: [logEmbed] })
 				})
 			else if (sendLogs) await verifyLogs.send({ embeds: [logEmbed] })
@@ -169,11 +174,11 @@ async function crowdinVerify(member: GuildMember, url?: string | null, sendDms =
 		if (sendDms) await member.send({ embeds: [errorEmbed] })
 			.then(async () => await verifyLogs.send(`${member} forgot to add their Discord to their profile (<${url}>). Let's hope they fix that with the message I just sent them.`))
 			.catch(async () => {
-				errorEmbed.setFooter("This message will be deleted in a minute")
+				errorEmbed.setFooter({ text: "This message will be deleted in a minute" })
 				await verifyLogs.send(`${member} forgot to add their Discord to their profile (<${url}>). Let's hope they fix that with the message I just sent in <#${ids.channels.verify}> since they had DMs off.`)
 				const msg = await verify.send({ content: `${member} you had DMs disabled, so here's our message,`, embeds: [errorEmbed] })
 				await setTimeout(60_000)
-				if (!msg.deleted) await msg.delete()
+				await msg.delete().catch(() => null)
 			})
 		if (sendLogs) await statsColl.insertOne({ type: "VERIFY", name: verifyType, user: member.id, error: true, errorMessage: "missingDiscordTag" })
 		return
@@ -255,12 +260,13 @@ async function crowdinVerify(member: GuildMember, url?: string | null, sendDms =
 		})
 	}
 
-	const logEmbed = new MessageEmbed()
-		.setColor("BLURPLE")
-		.setTitle(`${member.user.tag} is now verified!`)
-		.setDescription(Object.keys(endingMessageProjects).length
+	const logEmbed = new MessageEmbed({
+		color: "BLURPLE",
+		title: `${member.user.tag} is now verified!`,
+		description: Object.keys(endingMessageProjects).length
 			? `${member} has received the following roles:`
-			: `${member} has not received any roles. They do not translate for any of the projects.`)
+			: `${member} has not received any roles. They do not translate for any of the projects.`
+	})
 
 	if (Object.keys(endingMessageProjects).length) {
 		for (const [k, v] of Object.entries(endingMessageProjects)) {
@@ -281,19 +287,20 @@ async function crowdinVerify(member: GuildMember, url?: string | null, sendDms =
 	logEmbed.addField("Profile", url)
 
 	//#region return message
-	const dmEmbed = new MessageEmbed()
-		.setColor("BLURPLE")
-		.setAuthor("Received message from staff")
-		.setDescription(`Hey there!\nYou have successfully verified your Crowdin account${Object.keys(endingMessageProjects).length
+	const dmEmbed = new MessageEmbed({
+		color: "BLURPLE",
+		author: { name: "Received message from staff" },
+		description: `Hey there!\nYou have successfully verified your Crowdin account${Object.keys(endingMessageProjects).length
 			? " and you also received the corresponding roles on our Discord server! Make sure to check out <#699275092026458122> if you want to learn more about Crowdin." //getting-started
 			: "!\nSadly you didn't receive any roles because you don't translate for any of the projects we currently support.\nWhen you have started translating you can refresh your roles by running `/verify`"
-			}\nIf you wanna know more about all the projects we currently support, run \`/projects\` here.`)
-		.setFooter("Any messages you send here will be sent to staff upon confirmation.")
+			}\nIf you wanna know more about all the projects we currently support, run \`/projects\` here.`,
+		footer: { text: "Any messages you send here will be sent to staff upon confirmation." }
+	})
 
 	if (sendDms) member.send({ embeds: [dmEmbed] })
 		.then(async () => await verifyLogs.send({ embeds: [logEmbed] }))
 		.catch(async () => {
-			logEmbed.setFooter("Message not sent because user had DMs off")
+			logEmbed.setFooter({ text: "Message not sent because user had DMs off" })
 			await verifyLogs.send({ embeds: [logEmbed] })
 		})
 	else if (sendLogs) await verifyLogs.send({ embeds: [logEmbed] })
@@ -370,11 +377,8 @@ async function updateLanguageRoles(
 		if (role.name.includes("Translator") || role.name.includes("Proofreader")) addedRoles.push(role.name)
 	})
 
-	activeRoles
-		.filter(pj => !addedRoles.includes(pj))
-		.forEach(async p => {
-			await member.roles.add(member.guild.roles.cache.find(r => r.name === p)!.id, "User has received this role on Crowdin")
-		})
+	activeRoles.filter(pj => !addedRoles.includes(pj)).map(r => member.guild.roles.cache.find(role => role.name === r))
+	await member.roles.add(activeRoles, "User has received this role on Crowdin")
 
 	addedRoles
 		.filter(r => !activeRoles.includes(r))

--- a/src/lib/crowdinverify.ts
+++ b/src/lib/crowdinverify.ts
@@ -134,9 +134,7 @@ async function crowdinVerify(member: GuildMember, url?: string | null, sendDms =
 					color: "BLURPLE",
 					title: `${member.user.tag} is now verified!`,
 					description: `${member} has not received any roles. They do not translate for any of the projects.`,
-					fields: [
-						{ name: "Profile", value: url }
-					]
+					fields: [{ name: "Profile", value: url }]
 				})
 			if (sendDms) await member.send({ embeds: [dmEmbed] })
 				.then(async () => await verifyLogs.send({ embeds: [logEmbed] }))

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -325,10 +325,10 @@ export function updateModlogFields(embed: MessageEmbed, modlog: PunishmentLog, m
 	}
 	if (modlogs) embed
 		.setDescription(`Case #${modlog.case}`)
-		.setFooter(
-			`Modlog ${modlogs.indexOf(modlog) + 1}/${modlogs.length}`,
-			embed.footer!.iconURL
-		)
+		.setFooter({
+			text: `Modlog ${modlogs.indexOf(modlog) + 1}/${modlogs.length}`,
+			iconURL: embed.footer!.iconURL!
+		})
 	return embed
 }
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -291,7 +291,7 @@ export function updateButtonColors(row: MessageActionRow, page: number, pages: a
 }
 
 export function updateModlogFields(embed: MessageEmbed, modlog: PunishmentLog, modlogs?: PunishmentLog[]) {
-	embed.setAuthor({ name: "Log message", url: `https://discord.com/channels/549503328472530974/800820574405656587/${modlog.logMsg}` })
+	embed.setAuthor({ name: "Log message", url: `https://discord.com/channels/${ids.guilds.main}/${ids.channels.punishments}/${modlog.logMsg}` })
 	const expireTimestamp =
 		modlog.type === "VERBAL"
 			? new Date(modlog.timestamp).setDate(new Date(modlog.timestamp).getDate() + 1)

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -201,8 +201,7 @@ export async function awaitBan(punishment: PunishmentLog) {
 		punishmentsColl = db.collection<PunishmentLog>("punishments"),
 		punishmentsChannel = guild.channels.cache.get(ids.channels.punishments) as TextChannel,
 		caseNumber = (await punishmentsColl.estimatedDocumentCount()) + 1,
-		user = await guild.bans
-			.remove(punishment.id!, "Punishment ended")
+		user = await guild.bans.remove(punishment.id!, "Punishment ended")
 			.catch(err => console.error(`Couldn't unban user with id ${punishment.id}. Here's the error:\n`, err)),
 		userFetched = await client.users.fetch(punishment.id).catch(() => null),
 		punishmentLog = new MessageEmbed({

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -141,19 +141,20 @@ export async function awaitMute(punishment: PunishmentLog) {
 		caseNumber = (await punishmentsColl.estimatedDocumentCount()) + 1,
 		member = guild.members.cache.get(punishment.id!),
 		user = await client.users.fetch(punishment.id),
-		punishmentLog = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor({
+		punishmentLog = new MessageEmbed({
+			color: colors.success,
+			author: {
 				name: `Case ${caseNumber} | Unmute | ${user.tag}`,
 				iconURL: (member ?? user).displayAvatarURL({ format: "png", dynamic: true })
-			})
-			.addFields([
+			},
+			fields: [
 				{ name: "User", value: user.toString(), inline: true },
 				{ name: "Moderator", value: client.user.toString(), inline: true },
 				{ name: "Reason", value: "Ended" }
-			])
-			.setFooter(`ID: ${user.id}`)
-			.setTimestamp(),
+			],
+			footer: { text: `ID: ${user.id}` },
+			timestamp: Date.now()
+		}),
 		msg = await punishmentsChannel.send({ embeds: [punishmentLog] })
 	await punishmentsColl.bulkWrite([
 		{
@@ -181,12 +182,13 @@ export async function awaitMute(punishment: PunishmentLog) {
 			}
 		}
 	])
-	const dmEmbed = new MessageEmbed()
-		.setColor(colors.success)
-		.setAuthor("Punishment")
-		.setTitle(`Your mute on the ${guild.name} has expired.`)
-		.setDescription("You will now be able to talk in chats again. If something's wrong, please respond in this DM.")
-		.setTimestamp()
+	const dmEmbed = new MessageEmbed({
+		color: colors.success,
+		author: { name: "Punishment" },
+		title: `Your mute on the ${guild.name} has expired.`,
+		description: "You will now be able to talk in chats again. If something's wrong, please respond in this DM.",
+		timestamp: Date.now()
+	})
 	await user.send({ embeds: [dmEmbed] })
 		.catch(() => console.log(`Couldn't DM user ${user.tag}, (${user.id}) about their unmute.`))
 }
@@ -199,30 +201,33 @@ export async function awaitBan(punishment: PunishmentLog) {
 		punishmentsColl = db.collection<PunishmentLog>("punishments"),
 		punishmentsChannel = guild.channels.cache.get(ids.channels.punishments) as TextChannel,
 		caseNumber = (await punishmentsColl.estimatedDocumentCount()) + 1,
-		user = await guild.bans.remove(punishment.id!, "Punishment ended")
+		user = await guild.bans
+			.remove(punishment.id!, "Punishment ended")
 			.catch(err => console.error(`Couldn't unban user with id ${punishment.id}. Here's the error:\n`, err)),
 		userFetched = await client.users.fetch(punishment.id).catch(() => null),
-		punishmentLog = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor({
+		punishmentLog = new MessageEmbed({
+			color: colors.success,
+			author: {
 				name: `Case ${caseNumber} | Unban | ${userFetched?.tag ?? "Deleted User#0000"}`,
 				iconURL: userFetched?.displayAvatarURL({ format: "png", dynamic: true }) ?? client.user.defaultAvatarURL
-			})
-			.addFields([
+			},
+			fields: [
 				{ name: "User", value: `<@${punishment.id}>`, inline: true },
 				{ name: "Moderator", value: client.user.toString(), inline: true },
 				{ name: "Reason", value: "Ended" }
-			])
-			.setFooter(`ID: ${punishment.id}`)
-			.setTimestamp()
+			],
+			footer: { text: `ID: ${punishment.id}` },
+			timestamp: Date.now()
+		})
 	if (!user) punishmentLog.setDescription("Couldn't unban user from the server.")
 	else {
-		const dmEmbed = new MessageEmbed()
-			.setColor(colors.success)
-			.setAuthor("Punishment")
-			.setTitle(`Your ban on the ${guild.name} has expired.`)
-			.setDescription("You are welcome to join back using the invite in this message.")
-			.setTimestamp()
+		const dmEmbed = new MessageEmbed({
+			color: colors.success,
+			author: { name: "Punishment" },
+			title: `Your ban on the ${guild.name} has expired.`,
+			description: "You are welcome to join back using the invite in this message.",
+			timestamp: Date.now()
+		})
 		await user.send({ content: await getInviteLink(client), embeds: [dmEmbed] })
 			.catch(() => console.log(`Couldn't DM user ${userFetched?.tag ?? "Deleted User#0000"}, (${user.id}) about their unban.`))
 	}

--- a/src/listeners/voiceStateUpdate.ts
+++ b/src/listeners/voiceStateUpdate.ts
@@ -15,20 +15,27 @@ client.on("voiceStateUpdate", async (oldState, newState) => {
 			await newState.member!.roles.remove(ids.roles.voice, "Left a voice channel")
 
 		if (!!oldState.serverMute != !!newState.serverMute) { // Convert to boolean to prevent null != false from triggering the condition
-			const embed = new MessageEmbed()
-				.setColor(newState.serverMute ? errorColor : successColor)
-				.setAuthor({ name: newState.member!.user.tag, iconURL: newState.member!.displayAvatarURL({ format: "png", dynamic: true }) })
-				.setDescription(`**${newState.member} was server ${newState.serverMute ? "muted" : "unmuted"} in ${newState.channel?.name}**`)
-				.setFooter(`ID: ${newState.member!.id}`)
-				.setTimestamp()
+			const embed = new MessageEmbed({
+				color: newState.serverMute ? errorColor : successColor,
+				author: {
+					name: newState.member!.user.tag,
+					iconURL: newState.member!.displayAvatarURL({ format: "png", dynamic: true })
+				},
+				description: `**${newState.member} was server ${newState.serverMute ? "muted" : "unmuted"} in ${newState.channel?.name}**`,
+				timestamp: Date.now(),
+				footer: { text: `ID: ${newState.member!.id}` }
+			})
 			await logs.send({ embeds: [embed] })
 		} else if (!!oldState.serverDeaf != !!newState.serverDeaf) {
-			const embed = new MessageEmbed()
-				.setColor(newState.serverDeaf ? errorColor : successColor)
-				.setAuthor({ name: newState.member!.user.tag, iconURL: newState.member!.displayAvatarURL({ format: "png", dynamic: true }) })
-				.setDescription(`**${newState.member} was server ${newState.serverDeaf ? "deafened" : "undeafened"} in ${newState.channel?.name}**`)
-				.setFooter(`ID: ${newState.member!.id}`)
-				.setTimestamp()
+			const embed = new MessageEmbed({
+				color: newState.serverDeaf ? errorColor : successColor,
+				author: { name: newState.member!.user.tag, iconURL: newState.member!.displayAvatarURL({ format: "png", dynamic: true }) },
+				description: `**${newState.member} was server ${newState.serverDeaf ? "deafened" : "undeafened"} in ${
+					newState.channel?.name
+				}**`,
+				timestamp: Date.now(),
+				footer: { text: `ID: ${newState.member!.id}` }
+			})
 			await logs.send({ embeds: [embed] })
 		}
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**
In this PR every .set* and .add* function was replaced with the builder constructor (for embeds, action rows, buttons and select menus). I'm opening this so it can be reviewed and later merged. This is due to some changes discord.js did to the embed methods (deprecations added).
Also removed all instances of `*.deleted`, since that's deprecated, instead replacing them with a .catch()

**In this PR:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against on a separate test bot
- Code changes were not tested
- Environment variables were added/removed
- Core interfaces of the bot were edited (interfaces used in db.collection types e.g. DbUser, LangDbEntry, PunishmentLog and others)
- Strings were edited (text changed while the key stayed the same)
- Strings were added/removed (new/deleted string keys)
- An open issue was fixed/addressed: #
-->