### PR TITLE
feat(ReviewStrings): allow for multiple urls in a message

### DIFF
--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -71,19 +71,20 @@ client.on("messageCreate", async message => {
 	if (message.channel instanceof TextChannel && message.channel.name.endsWith("-review-strings")) {
 		if (stringURLRegex.test(message.content)) {
 			const urlsWithComments: string[] = [],
-				contentSplit = message.content.split(" ")
+				contentSplit = message.content.split(" "),
+				areUrls = contentSplit.map(w => stringURLRegex.test(w))
 
 			let commentAtStart = "",
-				encounteredUrl = stringURLRegex.test(contentSplit[0])
+				encounteredUrl = areUrls[0]
 
-			for (const word of contentSplit) {
-				if (stringURLRegex.test(word)) {
+			for (let i = 0; i < areUrls.length; i++) {
+				if (areUrls[i]) {
 					if (!encounteredUrl) {
-						urlsWithComments.push(`${commentAtStart}${word}`)
+						urlsWithComments.push(`${commentAtStart} ${contentSplit[i]}`)
 						encounteredUrl = true
-					} else urlsWithComments.push(word)
-				} else if (encounteredUrl) urlsWithComments[urlsWithComments.length - 1] += ` ${word}`
-				else commentAtStart += `${word} `
+					} else urlsWithComments.push(contentSplit[i])
+				} else if (encounteredUrl) urlsWithComments[urlsWithComments.length - 1] += ` ${contentSplit[i]}`
+				else commentAtStart += `${i ? " " : ""}${contentSplit[i]}`
 			}
 
 			if (urlsWithComments.length === 1) {
@@ -94,7 +95,9 @@ client.on("messageCreate", async message => {
 				for (const url of urlsWithComments) {
 					const msg = await message.channel.send({
 						content: `<@${message.author.id}>: ${url}`,
-						allowedMentions: { users: [] },
+						allowedMentions: {
+							users: [],
+						},
 					})
 					await msg.react("vote_yes:839262196797669427")
 					await msg.react("vote_maybe:839262179416211477")

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -69,16 +69,16 @@ client.on("messageCreate", async message => {
 	const stringURLRegex = /(https:\/\/)?crowdin\.com\/translate\/\w+\/(?:\d+|all)\/en(?:-\w+)?(?:\?[\w\d%&=$+!*'()-]*)?#\d+/gi
 
 	if (message.channel instanceof TextChannel && message.channel.name.endsWith("-review-strings") && !message.author.bot) {
-		const urlsWithComments: string[] = [],
-			contentSplit = message.content.split(" "),
-			areUrls = contentSplit.map(w => stringURLRegex.test(w))
-
-		if (areUrls.filter(u => u).length === 0) await message.delete().catch(() => null)
-		else if (areUrls.filter(u => u).length === 1) {
+		if (!stringURLRegex.test(message.content)) await message.delete().catch(() => null)
+		else if (message.content.match(stringURLRegex)!.length === 1) {
 			await message.react("vote_yes:839262196797669427")
 			await message.react("vote_maybe:839262179416211477")
 			await message.react("vote_no:839262184882044931")
 		} else {
+			const urlsWithComments: string[] = [],
+				contentSplit = message.content.split(" "),
+				areUrls = contentSplit.map(w => stringURLRegex.test(w))
+
 			let commentAtStart = "",
 				encounteredUrl = areUrls[0]
 

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -71,20 +71,19 @@ client.on("messageCreate", async message => {
 	if (message.channel instanceof TextChannel && message.channel.name.endsWith("-review-strings")) {
 		if (stringURLRegex.test(message.content)) {
 			const urlsWithComments: string[] = [],
-				contentSplit = message.content.split(" "),
-				areUrls = contentSplit.map(w => stringURLRegex.test(w))
+				contentSplit = message.content.split(" ")
 
 			let commentAtStart = "",
-				encounteredUrl = areUrls[0]
+				encounteredUrl = stringURLRegex.test(contentSplit[0])
 
-			for (let i = 0; i < areUrls.length; i++) {
-				if (areUrls[i]) {
+			for (const word of contentSplit) {
+				if (stringURLRegex.test(word)) {
 					if (!encounteredUrl) {
-						urlsWithComments.push(`${commentAtStart} ${contentSplit[i]}`)
+						urlsWithComments.push(`${commentAtStart}${word}`)
 						encounteredUrl = true
-					} else urlsWithComments.push(contentSplit[i])
-				} else if (encounteredUrl) urlsWithComments[urlsWithComments.length - 1] += ` ${contentSplit[i]}`
-				else commentAtStart += `${i ? " " : ""}${contentSplit[i]}`
+					} else urlsWithComments.push(word)
+				} else if (encounteredUrl) urlsWithComments[urlsWithComments.length - 1] += ` ${word}`
+				else commentAtStart += `${word} `
 			}
 
 			if (urlsWithComments.length === 1) {
@@ -95,9 +94,7 @@ client.on("messageCreate", async message => {
 				for (const url of urlsWithComments) {
 					const msg = await message.channel.send({
 						content: `<@${message.author.id}>: ${url}`,
-						allowedMentions: {
-							users: [],
-						},
+						allowedMentions: { users: [] },
 					})
 					await msg.react("vote_yes:839262196797669427")
 					await msg.react("vote_maybe:839262179416211477")

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -100,7 +100,7 @@ client.on("messageCreate", async message => {
 					await msg.react("vote_maybe:839262179416211477")
 					await msg.react("vote_no:839262184882044931")
 				}
-				await message.delete()
+				await message.delete().catch(() => null)
 			}
 		}
 	}

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -88,24 +88,22 @@ client.on("messageCreate", async message => {
 		else {
 			urlsWithComments[0] = `${commentAtStart} ${urlsWithComments[0]}`
 
-			let reactToMessages = [message]
-			if (urlsWithComments.length > 1) {
-				reactToMessages = []
+			if (urlsWithComments.length === 1) {
+				await message.react("vote_yes:839262196797669427")
+				await message.react("vote_maybe:839262179416211477")
+				await message.react("vote_no:839262184882044931")
+			} else {
 				for (const url of urlsWithComments) {
-					reactToMessages.push(
-						await message.channel.send({
-							content: `<@${message.author.id}>: ${url}`,
-							allowedMentions: {
-								users: []
-							}
-						})
-					)
+					const msg = await message.channel.send({
+						content: `<@${message.author.id}>: ${url}`,
+						allowedMentions: {
+							users: []
+						}
+					})
+					await msg.react("vote_yes:839262196797669427")
+					await msg.react("vote_maybe:839262179416211477")
+					await msg.react("vote_no:839262184882044931")
 				}
-			}
-			for (const msg of reactToMessages) {
-				await msg.react("vote_yes:839262196797669427")
-				await msg.react("vote_maybe:839262179416211477")
-				await msg.react("vote_no:839262184882044931")
 			}
 		}
 	}

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -104,6 +104,7 @@ client.on("messageCreate", async message => {
 					await msg.react("vote_maybe:839262179416211477")
 					await msg.react("vote_no:839262184882044931")
 				}
+				await message.delete()
 			}
 		}
 	}

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -66,7 +66,7 @@ client.on("messageCreate", async message => {
 		return void (await message.crosspost())
 
 	// Delete non-stringURL messages in review-strings
-	const stringURLRegex = /(https:\/\/)?crowdin\.com\/translate\/\w+\/(?:\d+|all)\/en(?:-\w+)?(?:\?[\w\d%&=$+!*'()-]*)?#\d+/gi
+	const stringURLRegex = /(https:\/\/)?crowdin\.com\/translate\/\w+\/(?:\d+|all)\/en(?:-\w+)?(?:\?[\w\d%&=$+!*'()-]*)?#\d+/i
 
 	if (message.channel instanceof TextChannel && message.channel.name.endsWith("-review-strings") && !message.author.bot) {
 		if (!stringURLRegex.test(message.content)) await message.delete().catch(() => null)
@@ -76,7 +76,7 @@ client.on("messageCreate", async message => {
 			await message.react("vote_no:839262184882044931")
 		} else {
 			const urlsWithComments: string[] = [],
-				contentSplit = message.content.split(" "),
+				contentSplit = message.content.split(/\s/).filter(Boolean),
 				areUrls = contentSplit.map(w => stringURLRegex.test(w))
 
 			let commentAtStart = "",

--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -35,7 +35,8 @@ client.on("messageReactionAdd", async (reaction, user) => {
 			} catch {
 				strings = require("../../strings/en/reviewStrings.json")
 			}
-			if (reaction.emoji.name === "vote_yes" && !reactedToOwn) {
+			if (reactedToOwn) await reaction.users.remove(user.id)
+			else if (reaction.emoji.name === "vote_yes") {
 				await reaction.message.react("⏱")
 				await setTimeout(10_000)
 				// Check if the user hasn't removed their reaction
@@ -49,7 +50,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
 					await statsColl.insertOne({ type: "STRINGS", user: user.id, name: "APPROVED" })
 					console.log(`String reviewed in ${channel.name}`)
 				} else await reaction.message.reactions.cache.get("⏱")?.remove()
-			} else if (reaction.emoji.name === "vote_maybe" && !reactedToOwn) {
+			} else if (reaction.emoji.name === "vote_maybe") {
 				await reaction.users.remove(user.id)
 				const embed = new MessageEmbed({
 						color: colors.loading,
@@ -73,7 +74,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
 					})
 				await thread.send({ content: `${user}`, embeds: [embed] })
 				await statsColl.insertOne({ type: "STRINGS", user: user.id, name: "MORE_INFO" })
-			} else if (reaction.emoji.name === "vote_no" && !reactedToOwn) {
+			} else if (reaction.emoji.name === "vote_no") {
 				await reaction.message.react("⏱")
 				const embed = new MessageEmbed({
 					color: colors.error,
@@ -107,7 +108,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
 					await statsColl.insertOne({ type: "STRINGS", user: user.id, name: "DENIED" })
 					console.log(`String rejected in ${channel.name}`)
 				} else await reaction.message.reactions.cache.get("⏱")?.remove()
-			} else await reaction.users.remove(user.id)
+			}
 		} else await reaction.users.remove(user.id)
 	} else if (
 		// Starboard system


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**
As said in the title, this PR makes the review strings system accept multiple urls in one message. If it detects more than one url in a message, it will delete the original messagem split the urls and attach additional comments to them, send them and react to each one.

**In this PR:**
- Code changes were not tested

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against on a separate test bot
- Environment variables were added/removed
- Core interfaces of the bot were edited (interfaces used in db.collection types e.g. DbUser, MongoLanguage, PunishmentLog and others)
- Strings were edited (text changed while the key stayed the same)
- Strings were added/removed (new/deleted string keys)
- An open issue was fixed/addressed: #
-->
