### PR TITLE
feat: nickname prefix vadalidation

### DIFF
--- a/src/commands/Admin/channel.ts
+++ b/src/commands/Admin/channel.ts
@@ -180,7 +180,7 @@ async function rules(interaction: ChatInputCommandInteraction<"cached">) {
 			{
 				name: "4 - Nicks",
 				value:
-					"Your nickname must not contain zalgo or a prefix for a language you do not translate (e.g. `[PT]` or `[🇵🇹]`). It should also obey the remaining rules.",
+					'Your nickname must not contain zalgo or a prefix for a language you do not translate. Additionally, prefixes should only include the flag(s) of the language(s) you translate, separated by a dash ("-") (e.g. `[🇵🇹]` or `[🇩🇪-🇪🇸]`) and nothing else (e.g. your role on the project or alternative acronyms to resemble your language). The only exception applies to Chinese translators, who can include "CS" or "CT" in their prefixes if they do not wish to use the flags. Nicknames should also obey the remaining rules.',
 			},
 			{
 				name: "5 - Do not excessively tag Discord and Hypixel Staff members/project managers.",

--- a/src/listeners/guildMemberUpdate.ts
+++ b/src/listeners/guildMemberUpdate.ts
@@ -20,8 +20,7 @@ client.on("guildMemberUpdate", async (oldMember, newMember) => {
 				color: colors.error,
 				author: { name: "Received a message from staff" },
 				description:
-					// TODO reference rule 4
-					"Hey there!\nWe noticed you changed your nickname to include a new prefix, however, prefixes must include country flags or language codes only, which yours doesn't.\nWe've reset your nickname back to the old one. If you have any questions or believe this is a bug, please contact the staff team.",
+					"Hey there!\nWe noticed you changed your nickname to include a new prefix, however it didn't comply with our rule about nicknames (rule 4).\nWe've reset your nickname back to the old one. If you have any questions or believe this is a bug, please contact the staff team.",
 			})
 			await newMember.setNickname(oldMember.nickname)
 			await newMember.send({ embeds: [embed] })
@@ -33,8 +32,7 @@ client.on("guildMemberUpdate", async (oldMember, newMember) => {
 				color: colors.error,
 				author: { name: "Received a message from staff" },
 				description:
-					// TODO reference rule 4
-					"Hey there!\nWe noticed your nickname included a prefix but didn't include country flags nor language codes.\nDue to this we've reset your nickname entirely. If you have any questions or believe this is a bug, please contact the staff team.",
+					"Hey there!\nWe noticed your nickname included a prefix but didn't include country flags nor allowed language codes (rule 4).\nDue to this, we've reset your nickname entirely. If you have any questions or believe this is a bug, please contact the staff team.",
 			})
 			await newMember.setNickname(null)
 			await newMember.send({ embeds: [embed] })

--- a/src/listeners/guildMemberUpdate.ts
+++ b/src/listeners/guildMemberUpdate.ts
@@ -1,0 +1,43 @@
+import { MessageEmbed } from "discord.js"
+
+import { colors } from "../config.json"
+import { client } from "../index"
+
+client.on("guildMemberUpdate", async (oldMember, newMember) => {
+	// Prefix validation
+	if (newMember.nickname && /\[[^\s]*\] ?/g.test(newMember.nickname) && oldMember.nickname !== newMember.nickname) {
+		const flagRegex = /\[\uD83C[\uDDE6-\uDDFF]\]/,
+			chineseRegex = /\[(?:(?:CS|CT)-?)+\]/
+
+		if (
+			(newMember.roles.cache.some(r => r.name.startsWith("Chinese ")) &&
+				!chineseRegex.test(newMember.nickname) &&
+				oldMember.nickname &&
+				chineseRegex.test(oldMember.nickname)) ||
+			(!flagRegex.test(newMember.nickname) && oldMember.nickname && flagRegex.test(oldMember.nickname))
+		) {
+			const embed = new MessageEmbed({
+				color: colors.error,
+				author: { name: "Received a message from staff" },
+				description:
+					// TODO reference rule 4
+					"Hey there!\nWe noticed you changed your nickname to include a new prefix, however, prefixes must include country flags or language codes only, which yours doesn't.\nWe've reset your nickname back to the old one. If you have any questions or believe this is a bug, please contact the staff team.",
+			})
+			await newMember.setNickname(oldMember.nickname)
+			await newMember.send({ embeds: [embed] })
+		} else if (
+			(newMember.roles.cache.some(r => r.name.startsWith("Chinese ")) && oldMember.nickname && chineseRegex.test(oldMember.nickname)) ||
+			(!flagRegex.test(newMember.nickname) && oldMember.nickname && flagRegex.test(oldMember.nickname))
+		) {
+			const embed = new MessageEmbed({
+				color: colors.error,
+				author: { name: "Received a message from staff" },
+				description:
+					// TODO reference rule 4
+					"Hey there!\nWe noticed your nickname included a prefix but didn't include country flags nor language codes.\nDue to this we've reset your nickname entirely. If you have any questions or believe this is a bug, please contact the staff team.",
+			})
+			await newMember.setNickname(null)
+			await newMember.send({ embeds: [embed] })
+		}
+	}
+})

--- a/src/listeners/guildMemberUpdate.ts
+++ b/src/listeners/guildMemberUpdate.ts
@@ -1,41 +1,78 @@
-import { MessageEmbed } from "discord.js"
+import { GuildMember, MessageEmbed, PartialGuildMember, TextChannel } from "discord.js"
 
-import { colors } from "../config.json"
+import { colors, ids } from "../config.json"
 import { client } from "../index"
 
 client.on("guildMemberUpdate", async (oldMember, newMember) => {
 	// Prefix validation
-	if (newMember.nickname && /\[[^\s]*\] ?/g.test(newMember.nickname) && oldMember.nickname !== newMember.nickname) {
-		const flagRegex = /\[\uD83C[\uDDE6-\uDDFF]\]/,
+	if (!newMember.manageable) return
+	if (newMember.nickname && /\[\S*\] ?/g.test(newMember.nickname) && oldMember.nickname !== newMember.nickname) {
+		// \u2620 is the unicode for the skull emoji, the other pattern is for letter emojis
+		const flagRegex = /\[(?:(?:\uD83C[\uDDE6-\uDDFF]){2}|\u2620)((-(?:(?:\uD83C[\uDDE6-\uDDFF]){2}|\u2620))?)+\]/,
 			chineseRegex = /\[(?:(?:CS|CT)-?)+\]/
 
-		if (
-			(newMember.roles.cache.some(r => r.name.startsWith("Chinese ")) &&
-				!chineseRegex.test(newMember.nickname) &&
-				oldMember.nickname &&
-				chineseRegex.test(oldMember.nickname)) ||
-			(!flagRegex.test(newMember.nickname) && oldMember.nickname && flagRegex.test(oldMember.nickname))
-		) {
-			const embed = new MessageEmbed({
-				color: colors.error,
-				author: { name: "Received a message from staff" },
-				description:
-					"Hey there!\nWe noticed you changed your nickname to include a new prefix, however it didn't comply with our rule about nicknames (rule 4).\nWe've reset your nickname back to the old one. If you have any questions or believe this is a bug, please contact the staff team.",
-			})
-			await newMember.setNickname(oldMember.nickname)
-			await newMember.send({ embeds: [embed] })
-		} else if (
-			(newMember.roles.cache.some(r => r.name.startsWith("Chinese ")) && oldMember.nickname && chineseRegex.test(oldMember.nickname)) ||
-			(!flagRegex.test(newMember.nickname) && oldMember.nickname && flagRegex.test(oldMember.nickname))
-		) {
-			const embed = new MessageEmbed({
-				color: colors.error,
-				author: { name: "Received a message from staff" },
-				description:
-					"Hey there!\nWe noticed your nickname included a prefix but didn't include country flags nor allowed language codes (rule 4).\nDue to this, we've reset your nickname entirely. If you have any questions or believe this is a bug, please contact the staff team.",
-			})
-			await newMember.setNickname(null)
-			await newMember.send({ embeds: [embed] })
-		}
+		if (flagRegex.test(newMember.nickname)) return
+		if (newMember.roles.cache.some(r => r.name.startsWith("Chinese "))) {
+			if (chineseRegex.test(newMember.nickname)) return
+			if (oldMember.nickname && (chineseRegex.test(oldMember.nickname) || flagRegex.test(oldMember.nickname)))
+				await sendRevertAlert(oldMember, newMember)
+			else await sendRemoveAlert(newMember)
+		} else if (oldMember.nickname && !flagRegex.test(oldMember.nickname)) await sendRevertAlert(oldMember, newMember)
+		else await sendRemoveAlert(newMember)
 	}
 })
+
+async function sendRevertAlert(oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) {
+	const embed = new MessageEmbed({
+			color: colors.error,
+			author: { name: "Received a message from staff" },
+			description: `Hey there!\nWe noticed you changed your nickname to include a new prefix, however it didn't comply with our rule about nicknames (rule 4).\nWe've reset your nickname back to the old one, however, if you'd like, you can fix your new nickname (${newMember.nickname}) and apply it again. If you have any questions or believe this is a bug, please contact the staff team.`,
+		}),
+		staffEmbed = new MessageEmbed({
+			color: colors.loading,
+			title: "Member nickname reverted",
+			description: `I noticed that ${newMember}'s new nickname: \`${newMember.nickname}\` didn't follow our rules, so I reverted it back to \`${oldMember.nickname}\`. Make sure this is correct and, if it isn't, feel free to undo.`,
+			timestamp: Date.now(),
+		}),
+		staffBots = client.channels.cache.get(ids.channels.staffBots) as TextChannel
+	await newMember.setNickname(oldMember.nickname)
+	await newMember
+		.send({ embeds: [embed] })
+		.then(async () => {
+			await staffBots.send({ embeds: [staffEmbed] })
+			console.log(`DM'd ${newMember.user.tag} with a message about their nickname being reverted.`)
+		})
+		.catch(async () => {
+			staffEmbed.setFooter({ text: "Couldn't send DM!" }).setColor(colors.error)
+			await staffBots.send({ embeds: [staffEmbed] })
+			console.log(`Couldn't ${newMember.user.tag} with a message about their nickname being reverted.`)
+		})
+}
+
+async function sendRemoveAlert(newMember: GuildMember) {
+	const embed = new MessageEmbed({
+			color: colors.error,
+			author: { name: "Received a message from staff" },
+			description:
+				"Hey there!\nWe noticed your nickname included a prefix but didn't include country flags nor allowed language codes (rule 4).\nDue to this, we've reset your nickname entirely. If you have any questions or believe this is a bug, please contact the staff team.",
+		}),
+		staffEmbed = new MessageEmbed({
+			color: colors.loading,
+			title: "Member nickname removed",
+			description: `I noticed that ${newMember}'s new nickname: \`${newMember.nickname}\` didn't follow our rules, and neither did their old one, so I removed their nickname entirely. Make sure this is correct and, if it isn't, feel free to undo.`,
+			timestamp: Date.now(),
+		}),
+		staffBots = client.channels.cache.get(ids.channels.staffBots) as TextChannel
+	await newMember.setNickname(null)
+	await newMember
+		.send({ embeds: [embed] })
+		.then(async () => {
+			await staffBots.send({ embeds: [staffEmbed] })
+			console.log(`DM'd ${newMember.user.tag} with a message about their nicknam being removed.`)
+		})
+		.catch(async () => {
+			staffEmbed.setFooter({ text: "Couldn't send DM!" }).setColor(colors.error)
+			await staffBots.send({ embeds: [staffEmbed] })
+			console.log(`Couldn't DM ${newMember.user.tag} with a message about their nicknam being removed.`)
+		})
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**
Adds a system that checks if a persons prefix is a flag (or a language code in case of Chinese) when a user updates their nickname.

**In this PR:**
- Code changes were not tested

<!--
Please move lines that apply to you out of the comment:
- Code changes were not tested
- Environment variables were added/removed
- Core interfaces of the bot were edited (interfaces used in db.collection types e.g. DbUser, MongoLanguage, PunishmentLog and others)
- Strings were edited (text changed while the key stayed the same)
- Strings were added/removed (new/deleted string keys)
- An open issue was fixed/addressed: #
-->
