### PR TITLE
feat(eval): format input and compiled code

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"language-flag-colors": "^2.0.4",
 		"mongodb": "^4.4.0",
 		"node-cron": "^3.0.0",
+		"prettier": "^2.5.1",
 		"puppeteer": "^13.4.1",
 		"source-map-support": "^0.5.21",
 		"typescript": "^4.6.2",
@@ -34,6 +35,7 @@
 	"devDependencies": {
 		"@types/node": "^16.11.26",
 		"@types/node-cron": "^3.0.1",
+		"@types/prettier": "^2.4.4",
 		"@types/uuid": "^8.3.4",
 		"@typescript-eslint/eslint-plugin": "^5.13.0",
 		"@typescript-eslint/parser": "^5.13.0",
@@ -44,7 +46,6 @@
 		"eslint-plugin-import": "^2.25.3",
 		"eslint-plugin-no-one-time-vars": "^2.2.0",
 		"eslint-plugin-prettier": "^4.0.0",
-		"prettier": "^2.5.1",
 		"rimraf": "^3.0.2"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,6 +153,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.26.tgz#63d204d136c9916fb4dcd1b50f9740fe86884e47"
   integrity sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==
 
+"@types/prettier@^2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"
+  integrity sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
+
 "@types/uuid@^8.3.4":
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**

This PR adds prettier to eval command to format input and compiled code.
_To copy raw input code click to the command name in the interaction reply message and copy here_

**In this PR:**
- Code changes were not tested
