### PR TITLE
fix: improve prefix regex

### DIFF
--- a/src/commands/Utility/prefix.ts
+++ b/src/commands/Utility/prefix.ts
@@ -34,7 +34,7 @@ const command: Command = {
 	async execute(interaction, getString: GetStringFunction) {
 		if (!interaction.inCachedGuild()) return
 		const randomTip = generateTip(getString),
-			nickNoPrefix = interaction.member.displayName.replaceAll(/\[[^\s]*\] ?/g, "").trim(),
+			nickNoPrefix = interaction.member.displayName.replaceAll(/\[[^.]*\] ?/g, "").trim(),
 			languages = await db.collection<MongoLanguage>("languages").find().toArray()
 
 		if (interaction.options.getString("flags", false) && !interaction.member.roles.cache.hasAny(ids.roles.hypixelTranslator, ids.roles.hypixelPf)) {

--- a/src/commands/Utility/prefix.ts
+++ b/src/commands/Utility/prefix.ts
@@ -34,7 +34,7 @@ const command: Command = {
 	async execute(interaction, getString: GetStringFunction) {
 		if (!interaction.inCachedGuild()) return
 		const randomTip = generateTip(getString),
-			nickNoPrefix = interaction.member.displayName.replaceAll(/\[[^.]*\] ?/g, "").trim(),
+			nickNoPrefix = interaction.member.displayName.replaceAll(/\[.*\] ?/g, "").trim(),
 			languages = await db.collection<MongoLanguage>("languages").find().toArray()
 
 		if (interaction.options.getString("flags", false) && !interaction.member.roles.cache.hasAny(ids.roles.hypixelTranslator, ids.roles.hypixelPf)) {

--- a/src/listeners/guildMemberUpdate.ts
+++ b/src/listeners/guildMemberUpdate.ts
@@ -6,7 +6,7 @@ import { client } from "../index"
 client.on("guildMemberUpdate", async (oldMember, newMember) => {
 	// Prefix validation
 	if (!newMember.manageable) return
-	if (newMember.nickname && /\[\S*\] ?/g.test(newMember.nickname) && oldMember.nickname !== newMember.nickname) {
+	if (newMember.nickname && /\[\.*\]/g.test(newMember.nickname) && oldMember.nickname !== newMember.nickname) {
 		// \u2620 is the unicode for the skull emoji, the other pattern is for letter emojis
 		const flagRegex = /\[(?:(?:\uD83C[\uDDE6-\uDDFF]){2}|\u2620)((-(?:(?:\uD83C[\uDDE6-\uDDFF]){2}|\u2620))?)+\]/,
 			chineseRegex = /\[(?:(?:CS|CT)-?)+\]/


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**
This PR changes the prefix checking regex so people can't bypass it by adding spaces

**In this PR:**
- Code changes were not tested (they been tested on a regex tester tho)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against on a separate test bot
- Environment variables were added/removed
- Core interfaces of the bot were edited (interfaces used in db.collection types e.g. DbUser, MongoLanguage, PunishmentLog and others)
- Strings were edited (text changed while the key stayed the same)
- Strings were added/removed (new/deleted string keys)
- An open issue was fixed/addressed: #
-->
