### PR TITLE
feat: don't remove project roles when user is pending

### DIFF
--- a/src/lib/crowdinverify.ts
+++ b/src/lib/crowdinverify.ts
@@ -254,7 +254,7 @@ export async function crowdinVerify(member: GuildMember, url?: string | null, se
 	const joinedProjects: string[] = []
 
 	projects
-		.filter(project => Object.keys(projectIDs).includes(project.id) && project.user_role !== "pending")
+		.filter(project => Object.keys(projectIDs).includes(project.id))
 		.forEach(async project => {
 			if (!project.contributed_languages?.length && !["owner", "manager"].includes(project.user_role) && projectIDs[project.id].langRoles)
 				return removeProjectRoles("Hypixel", member)

--- a/src/lib/crowdinverify.ts
+++ b/src/lib/crowdinverify.ts
@@ -372,6 +372,8 @@ export async function crowdinVerify(member: GuildMember, url?: string | null, se
 }
 
 async function updateProjectRoles(projectName: ValidProjects, member: GuildMember, project: CrowdinProject) {
+	if (project.user_role === "pending") return
+
 	const languages = project.contributed_languages?.length
 			? project.contributed_languages.map(lang => ({
 					lang: lang.code,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**
This PR adds a check to the updateProjectRoles function in src/lib/crowdinverify.ts so that when the user is pending on a project, their project roles aren't removed.


**In this PR:**
- Code changes were not tested

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against on a separate test bot
- Environment variables were added/removed
- Core interfaces of the bot were edited (interfaces used in db.collection types e.g. DbUser, MongoLanguage, PunishmentLog and others)
- Strings were edited (text changed while the key stayed the same)
- Strings were added/removed (new/deleted string keys)
- An open issue was fixed/addressed: #
-->
